### PR TITLE
[README.md] Fix typo in OAuth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let swifter = Swifter(consumerKey: "", consumerSecret: "", appOnly: true)
 
 ```swift
 swifter.authorizeWithCallbackURL(callbackURL, success: {
-	(accessToken: SwifterCredential.OAuthAccessToken, response: NSURLResponse) in
+	(accessToken: SwifterCredential.OAuthAccessToken?, response: NSURLResponse) in
 
 	// ...
 


### PR DESCRIPTION
The success handler's access token is defined as an optional value in the implementation.

``` swift
public typealias TokenSuccessHandler = (accessToken: SwifterCredential.OAuthAccessToken?, response: NSURLResponse) -> Void
```
