### PR TITLE
Fixed getStatusesShowWithID: setting "id" parameter.

### DIFF
--- a/Swifter/SwifterTweets.swift
+++ b/Swifter/SwifterTweets.swift
@@ -75,6 +75,7 @@ public extension Swifter {
         let path = "statuses/show.json"
 
         var parameters = Dictionary<String, AnyObject>()
+        parameters["id"] = id
         if count != nil {
             parameters["count"] = count!
         }


### PR DESCRIPTION
I found that parameter "id" is not set in "getStatusesShowWithID()" and causes 404 response.

I hope it helps.
