### PR TITLE
Change + to +| for Dictionary+Swifter.swift

### DIFF
--- a/Swifter/Dictionary+Swifter.swift
+++ b/Swifter/Dictionary+Swifter.swift
@@ -67,8 +67,8 @@ extension Dictionary {
     
 }
 
-infix operator + {}
-func + <K,V>(left: Dictionary<K,V>, right: Dictionary<K,V>) -> Dictionary<K,V> {
+infix operator +| {}
+func +| <K,V>(left: Dictionary<K,V>, right: Dictionary<K,V>) -> Dictionary<K,V> {
     var map = Dictionary<K,V>()
     for (k, v) in left {
         map[k] = v

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -128,7 +128,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
             }
         }
 
-        let combinedParameters = authorizationParameters + parameters
+        let combinedParameters = authorizationParameters +| parameters
 
         let finalParameters = isMediaUpload ? authorizationParameters : combinedParameters
 


### PR DESCRIPTION
Fixes issue where + operator was breaking for normal math in file that
the framework was imported into.
