### PR TITLE
Support Swift language changes in Xcode 6.1

### DIFF
--- a/Swifter/JSON.swift
+++ b/Swifter/JSON.swift
@@ -370,6 +370,10 @@ extension JSON : StringLiteralConvertible {
     public static func convertFromExtendedGraphemeClusterLiteral(value: String) -> JSON {
         return .JSONString(value)
     }
+    
+    public static func convertFromUnicodeScalarLiteral(value: String) -> JSON {
+        return .JSONString(value)
+    }
 
 }
 

--- a/Swifter/NSURL+Swifter.swift
+++ b/Swifter/NSURL+Swifter.swift
@@ -41,7 +41,7 @@ extension NSURL {
 
         let URLString = absoluteURLString + (absoluteURLString.rangeOfString("?") != nil ? "&" : "?") + queryString
 
-        return NSURL(string: URLString)
+        return NSURL(string: URLString)!
     }
 
 }

--- a/Swifter/Swifter.swift
+++ b/Swifter/Swifter.swift
@@ -72,31 +72,31 @@ public class Swifter {
             self.client = SwifterOAuthClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
         }
 
-        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")
-        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")
-        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")
-        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")
-        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")
+        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")!
+        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")!
+        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")!
+        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")!
+        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")!
     }
 
     public init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
         self.client = SwifterOAuthClient(consumerKey: consumerKey, consumerSecret: consumerSecret , accessToken: oauthToken, accessTokenSecret: oauthTokenSecret)
 
-        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")
-        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")
-        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")
-        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")
-        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")
+        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")!
+        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")!
+        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")!
+        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")!
+        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")!
     }
 
     public init(account: ACAccount) {
         self.client = SwifterAccountsClient(account: account)
 
-        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")
-        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")
-        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")
-        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")
-        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")
+        self.apiURL = NSURL(string: "https://api.twitter.com/1.1/")!
+        self.uploadURL = NSURL(string: "https://upload.twitter.com/1.1/")!
+        self.streamURL = NSURL(string: "https://stream.twitter.com/1.1/")!
+        self.userStreamURL = NSURL(string: "https://userstream.twitter.com/1.1/")!
+        self.siteStreamURL = NSURL(string: "https://sitestream.twitter.com/1.1/")!
     }
 
     deinit {
@@ -119,7 +119,7 @@ public class Swifter {
             }
             else {
                 let jsonString = NSString(data: data, encoding: NSUTF8StringEncoding)
-                let jsonChunks = jsonString.componentsSeparatedByString("\r\n") as [String]
+                let jsonChunks = jsonString!.componentsSeparatedByString("\r\n") as [String]
 
                 for chunk in jsonChunks {
                     if chunk.utf16Count == 0 {

--- a/Swifter/SwifterAppOnlyClient.swift
+++ b/Swifter/SwifterAppOnlyClient.swift
@@ -44,7 +44,7 @@ internal class SwifterAppOnlyClient: SwifterClientProtocol  {
         let url = NSURL(string: path, relativeToURL: baseURL)
         let method = "GET"
 
-        let request = SwifterHTTPRequest(URL: url, method: method, parameters: parameters)
+        let request = SwifterHTTPRequest(URL: url!, method: method, parameters: parameters)
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure
@@ -61,7 +61,7 @@ internal class SwifterAppOnlyClient: SwifterClientProtocol  {
         let url = NSURL(string: path, relativeToURL: baseURL)
         let method = "POST"
 
-        let request = SwifterHTTPRequest(URL: url, method: method, parameters: parameters)
+        let request = SwifterHTTPRequest(URL: url!, method: method, parameters: parameters)
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure

--- a/Swifter/SwifterAuth.swift
+++ b/Swifter/SwifterAuth.swift
@@ -61,10 +61,10 @@ public extension Swifter {
                 })
 
             let authorizeURL = NSURL(string: "/oauth/authorize", relativeToURL: self.apiURL)
-            let queryURL = NSURL(string: authorizeURL.absoluteString! + "?oauth_token=\(token!.key)")
+            let queryURL = NSURL(string: authorizeURL!.absoluteString! + "?oauth_token=\(token!.key)")
 
             #if os(iOS)
-                UIApplication.sharedApplication().openURL(queryURL)
+                UIApplication.sharedApplication().openURL(queryURL!)
             #else
                 NSWorkspace.sharedWorkspace().openURL(queryURL)
             #endif
@@ -150,7 +150,7 @@ public extension Swifter {
             data, response in
 
             let responseString = NSString(data: data, encoding: NSUTF8StringEncoding)
-            let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString)
+            let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString!)
             success(accessToken: accessToken, response: response)
 
             }, failure: failure)
@@ -168,7 +168,7 @@ public extension Swifter {
                 data, response in
 
                 let responseString = NSString(data: data, encoding: NSUTF8StringEncoding)
-                let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString)
+                let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString!)
                 success(accessToken: accessToken, response: response)
 
                 }, failure: failure)

--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -235,7 +235,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
 
         if self.response.statusCode >= 400 {
             let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
-            let localizedDescription = SwifterHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString)
+            let localizedDescription = SwifterHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString!)
             let userInfo = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
             let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
             self.failureHandler?(error: error)
@@ -257,7 +257,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
         }
 
-        return NSString(data: data, encoding: encoding)
+        return NSString(data: data, encoding: encoding)!
     }
 
     class func descriptionForHTTPStatus(status: Int, responseString: String) -> String {

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -57,7 +57,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
     }
 
     func get(path: String, baseURL: NSURL, parameters: Dictionary<String, AnyObject>, uploadProgress: SwifterHTTPRequest.UploadProgressHandler?, downloadProgress: SwifterHTTPRequest.DownloadProgressHandler?, success: SwifterHTTPRequest.SuccessHandler?, failure: SwifterHTTPRequest.FailureHandler?) {
-        let url = NSURL(string: path, relativeToURL: baseURL)
+        let url = NSURL(string: path, relativeToURL: baseURL)!
         let method = "GET"
 
         let request = SwifterHTTPRequest(URL: url, method: method, parameters: parameters)
@@ -71,7 +71,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
     }
 
     func post(path: String, baseURL: NSURL, var parameters: Dictionary<String, AnyObject>, uploadProgress: SwifterHTTPRequest.UploadProgressHandler?, downloadProgress: SwifterHTTPRequest.DownloadProgressHandler?, success: SwifterHTTPRequest.SuccessHandler?, failure: SwifterHTTPRequest.FailureHandler?) {
-        let url = NSURL(string: path, relativeToURL: baseURL)
+        let url = NSURL(string: path, relativeToURL: baseURL)!
         let method = "POST"
 
         var postData: NSData?

--- a/SwifterDemoiOS/AuthViewController.swift
+++ b/SwifterDemoiOS/AuthViewController.swift
@@ -74,7 +74,7 @@ class AuthViewController: UIViewController {
             }
         }
         else {
-            swifter.authorizeWithCallbackURL(NSURL(string: "swifter://success"), success: {
+            swifter.authorizeWithCallbackURL(NSURL(string: "swifter://success")!, success: {
                 accessToken, response in
 
                 self.fetchTwitterHomeStream()

--- a/SwifterDemoiOS/TweetsViewController.swift
+++ b/SwifterDemoiOS/TweetsViewController.swift
@@ -47,7 +47,7 @@ class TweetsViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .Subtitle, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: .Subtitle, reuseIdentifier: nil)!
 
         cell.textLabel!.text = tweets[indexPath.row]["text"].string
         


### PR DESCRIPTION
(Note these changes will not work with Xcode 6.0)
- Added UnicodeScalarLiteralConvertible protocol to JSON
- Added explicit unwrapping where needed e.g. optional NSURL (ideally
  we should check for errors first before using the returned objects),
  UITableViewCell constructor is now also optional
