### PR TITLE
Fixing compile error on beta6-1 branch

### DIFF
--- a/Swifter/SwifterAuth.swift
+++ b/Swifter/SwifterAuth.swift
@@ -66,7 +66,7 @@ public extension Swifter {
             #if os(iOS)
                 UIApplication.sharedApplication().openURL(queryURL!)
             #else
-                NSWorkspace.sharedWorkspace().openURL(queryURL)
+                NSWorkspace.sharedWorkspace().openURL(queryURL!)
             #endif
             }, failure: failure)
     }


### PR DESCRIPTION
SwifterAuth.swift:69:55: error: value of optional type 'NSURL?' not unwrapped; did you mean to use '!' or '?'?
                NSWorkspace.sharedWorkspace().openURL(queryURL)
