### PR TITLE
Execute network request in current thread instead of main thread

### DIFF
--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -166,10 +166,10 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
         }
 
-        dispatch_async(dispatch_get_main_queue()) {
-            self.connection = NSURLConnection(request: self.request!, delegate: self)
-            self.connection.start()
+        self.connection = NSURLConnection(request: self.request!, delegate: self)
+        self.connection.start()
 
+        dispatch_async(dispatch_get_main_queue()) {
             #if os(iOS)
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = true
             #endif


### PR DESCRIPTION
Handle network request callbacks in whatever thread started it, instead of main thread.

The performance for `JSON.parseJSONData` is not optimized for large chunk of JSON data. Giving developer the choice of handling the network response in another thread make performance improvements possible.