### PR TITLE
JSON parsing performance

### DIFF
--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -166,10 +166,10 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
         }
 
-        self.connection = NSURLConnection(request: self.request!, delegate: self)
-        self.connection.start()
-
         dispatch_async(dispatch_get_main_queue()) {
+            self.connection = NSURLConnection(request: self.request!, delegate: self)
+            self.connection.start()
+
             #if os(iOS)
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = true
             #endif

--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -166,10 +166,10 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
             }
         }
 
-        dispatch_async(dispatch_get_main_queue()) {
-            self.connection = NSURLConnection(request: self.request!, delegate: self)
-            self.connection.start()
+        self.connection = NSURLConnection(request: self.request!, delegate: self)
+        self.connection.start()
 
+        dispatch_async(dispatch_get_main_queue()) {
             #if os(iOS)
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = true
             #endif


### PR DESCRIPTION
Defer `JSON.parseJSONData` to background thread, so that large chunk of JSON data won't block main thread.

I encountered this main thread lagging issue when requesting 154 friends data from API. Instruments showed time spending in JSON parsing is huge. With this commit, background thread usage increased with a meaningful amount.