### PR TITLE
Replaced all `id: Int` with `id: String` ( There was a corresponding leakage )

### DIFF
--- a/Swifter/SwifterFavorites.swift
+++ b/Swifter/SwifterFavorites.swift
@@ -114,7 +114,7 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func postDestroyFavoriteWithID(id: Int, includeEntities: Bool?, success: ((status: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postDestroyFavoriteWithID(id: String, includeEntities: Bool?, success: ((status: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "favorites/destroy.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -140,7 +140,7 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func postCreateFavoriteWithID(id: Int, includeEntities: Bool?, success: ((status: Dictionary<String, JSONValue>?) -> Void)?, failure: SwifterHTTPRequest.FailureHandler?) {
+    public func postCreateFavoriteWithID(id: String, includeEntities: Bool?, success: ((status: Dictionary<String, JSONValue>?) -> Void)?, failure: SwifterHTTPRequest.FailureHandler?) {
         let path = "favorites/create.json"
 
         var parameters = Dictionary<String, AnyObject>()

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -57,7 +57,7 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFriendsIDsWithID(id: Int, cursor: Int?, stringifyIDs: Bool?, count: Int?, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
+    public func getFriendsIDsWithID(id: String, cursor: Int?, stringifyIDs: Bool?, count: Int?, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
         let path = "friends/ids.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -124,7 +124,7 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFollowersIDsWithID(id: Int, cursor: Int?, stringifyIDs: Bool?, count: Int?, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
+    public func getFollowersIDsWithID(id: String, cursor: Int?, stringifyIDs: Bool?, count: Int?, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
         let path = "followers/ids.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -249,7 +249,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postCreateFriendshipWithID(id: Int, follow: Bool?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postCreateFriendshipWithID(id: String, follow: Bool?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -296,7 +296,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postDestroyFriendshipWithID(id: Int, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postDestroyFriendshipWithID(id: String, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -331,7 +331,7 @@ public extension Swifter {
 
     Allows one to enable or disable retweets and device notifications from the specified user.
     */
-    public func postUpdateFriendshipWithID(id: Int, device: Bool?, retweets: Bool?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postUpdateFriendshipWithID(id: String, device: Bool?, retweets: Bool?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -380,7 +380,7 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func getFriendshipsShowWithSourceID(sourceID: Int?, targetID: Int?, orTargetScreenName targetScreenName: String?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func getFriendshipsShowWithSourceID(sourceID: String?, targetID: String?, orTargetScreenName targetScreenName: String?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -402,7 +402,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFriendshipsShowWithSourceScreenName(sourceScreenName: String?, targetID: Int?, orTargetScreenName targetScreenName: String?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func getFriendshipsShowWithSourceScreenName(sourceScreenName: String?, targetID: String?, orTargetScreenName targetScreenName: String?, success: ((user: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -431,7 +431,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFriendsListWithID(id: Int, cursor: Int?, count: Int?, skipStatus: Bool?, includeUserEntities: Bool?, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
+    public func getFriendsListWithID(id: String, cursor: Int?, count: Int?, skipStatus: Bool?, includeUserEntities: Bool?, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -502,7 +502,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFollowersListWithID(id: Int, cursor: Int?, count: Int?, skipStatus: Bool?, includeUserEntities: Bool?, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
+    public func getFollowersListWithID(id: String, cursor: Int?, count: Int?, skipStatus: Bool?, includeUserEntities: Bool?, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, AnyObject>()

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -577,7 +577,7 @@ public extension Swifter {
 
     Returns a collection of users that the specified user can "contribute" to.
     */
-    public func getUsersContributeesWithUserID(id: Int, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSONValue]?) -> Void)?, failure: FailureHandler?) {
+    public func getUsersContributeesWithUserID(id: String, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSONValue]?) -> Void)?, failure: FailureHandler?) {
         let path = "users/contributees.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -626,7 +626,7 @@ public extension Swifter {
 
     Returns a collection of users who can contribute to the specified account.
     */
-    public func getUsersContributorsWithUserID(id: Int, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSONValue]?) -> Void)?, failure: FailureHandler?) {
+    public func getUsersContributorsWithUserID(id: String, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSONValue]?) -> Void)?, failure: FailureHandler?) {
         let path = "users/contributors.json"
 
         var parameters = Dictionary<String, AnyObject>()


### PR DESCRIPTION
There was a corresponding leakage. :disappointed_relieved: #60