### PR TITLE
Loading Cursors as Strings and not Ints to prevent overflowing on 32-bit devices (Swift.Int)

### DIFF
--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -445,7 +445,8 @@
 		8B9F50E51944A5AB00894629 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Matt Donnelly";
 				TargetAttributes = {
 					8B300C1E1944AA1A00993175 = {
@@ -671,6 +672,7 @@
 				INFOPLIST_FILE = SwifterDemoiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -685,6 +687,7 @@
 				INFOPLIST_FILE = SwifterDemoiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -703,6 +706,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -719,6 +723,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -788,6 +793,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -862,6 +868,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Swifter/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
@@ -878,6 +885,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Swifter/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
@@ -902,6 +910,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -924,6 +933,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				METAL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/Swifter.xcodeproj/xcshareddata/xcschemes/SwifterMac.xcscheme
+++ b/Swifter.xcodeproj/xcshareddata/xcschemes/SwifterMac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,8 @@
       buildConfiguration = "Debug">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -38,6 +40,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Swifter.xcodeproj/xcshareddata/xcschemes/SwifteriOS.xcscheme
+++ b/Swifter.xcodeproj/xcshareddata/xcschemes/SwifteriOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,8 @@
       buildConfiguration = "Debug">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -38,6 +40,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Swifter/Dictionary+Swifter.swift
+++ b/Swifter/Dictionary+Swifter.swift
@@ -49,7 +49,7 @@ extension Dictionary {
             parts.append(query)
         }
 
-        return join("&", parts)
+        return "&".join(parts)
     }
 
     func urlEncodedQueryStringWithEncoding(encoding: NSStringEncoding) -> String {
@@ -62,7 +62,7 @@ extension Dictionary {
             parts.append(query)
         }
 
-        return join("&", parts)
+        return "&".join(parts)
     }
     
 }

--- a/Swifter/Info.plist
+++ b/Swifter/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Swifter/JSON.swift
+++ b/Swifter/JSON.swift
@@ -156,9 +156,6 @@ public enum JSON : Equatable, Printable {
         switch self {
         case .JSONString(let value):
             return value
-        case .JSONNumber(let value):
-            return "\(UInt64(value))"
-            
         default:
             return nil
         }

--- a/Swifter/JSON.swift
+++ b/Swifter/JSON.swift
@@ -156,6 +156,8 @@ public enum JSON : Equatable, Printable {
         switch self {
         case .JSONString(let value):
             return value
+        case .JSONNumber(let value):
+            return "\(UInt64(value))"
             
         default:
             return nil

--- a/Swifter/JSON.swift
+++ b/Swifter/JSON.swift
@@ -32,7 +32,7 @@ public let JSONFalse = JSONValue(false)
 
 public let JSONNull = JSONValue.JSONNull
 
-public enum JSON : Equatable, Printable {
+public enum JSON : Equatable, CustomStringConvertible {
     
     case JSONString(String)
     case JSONNumber(Double)
@@ -100,10 +100,10 @@ public enum JSON : Equatable, Printable {
         if let value : AnyObject = rawValue {
             switch value {
             case let data as NSData:
-                if let jsonObject : AnyObject = NSJSONSerialization.JSONObjectWithData(data, options: nil, error: nil) {
+                do {
+                    let jsonObject : AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: [])
                     self = JSON(jsonObject)
-                }
-                else {
+                } catch _ {
                     self = .JSONInvalid
                 }
 
@@ -116,7 +116,7 @@ public enum JSON : Equatable, Printable {
                 
             case let dict as NSDictionary:
                 var newDict : Dictionary<String, JSONValue> = [:]
-                for (k : AnyObject, v : AnyObject) in dict {
+                for (k, v): (AnyObject, AnyObject) in dict {
                     if let key = k as? String {
                         newDict[key] = JSON(v)
                     }
@@ -139,7 +139,7 @@ public enum JSON : Equatable, Printable {
                     self = .JSONNumber(number.doubleValue)
                 }
                 
-            case let null as NSNull:
+            case  _ as NSNull:
                 self = .JSONNull
                 
             default:
@@ -236,18 +236,24 @@ public enum JSON : Equatable, Printable {
         }
     }
 
-    static func parseJSONData(jsonData : NSData, error: NSErrorPointer) -> JSON? {
-        var JSONObject : AnyObject! = NSJSONSerialization.JSONObjectWithData(jsonData, options: .MutableContainers, error: error)
+    static func parseJSONData(jsonData : NSData) throws -> JSON {
+        var JSONObject : AnyObject!
+        do {
+            JSONObject = try NSJSONSerialization.JSONObjectWithData(jsonData, options: .MutableContainers)
+        } catch _ {
+            JSONObject = nil
+        }
 
         return (JSONObject == nil) ? nil : JSON(JSONObject)
     }
 
-    static func parseJSONString(jsonString : String, error: NSErrorPointer) -> JSON? {
+    static func parseJSONString(jsonString : String) throws -> JSON {
+        let error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
         if let data = jsonString.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
-            return parseJSONData(data, error: error)
+            return try parseJSONData(data)
         }
         
-        return nil
+        throw error
     }
 
     func stringify(indent: String = "  ") -> String? {
@@ -288,7 +294,7 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
     }
 }
 
-extension JSON: Printable {
+extension JSON {
 
     public var description: String {
         if let jsonString = stringify() {
@@ -300,7 +306,7 @@ extension JSON: Printable {
     }
 
     private func _prettyPrint(indent: String, _ level: Int) -> String {
-        let currentIndent = join(indent, map(0...level, { _ in "" }))
+        let currentIndent = indent.join((0...level).map({ _ in "" }))
         let nextIndent = currentIndent + "  "
         
         switch self {
@@ -314,10 +320,10 @@ extension JSON: Printable {
             return "\"\(string)\""
             
         case .JSONArray(let array):
-            return "[\n" + join(",\n", array.map({ "\(nextIndent)\($0._prettyPrint(indent, level + 1))" })) + "\n\(currentIndent)]"
+            return "[\n" + ",\n".join(array.map({ "\(nextIndent)\($0._prettyPrint(indent, level + 1))" })) + "\n\(currentIndent)]"
             
         case .JSONObject(let dict):
-            return "{\n" + join(",\n", map(dict, { "\(nextIndent)\"\($0)\" : \($1._prettyPrint(indent, level + 1))"})) + "\n\(currentIndent)}"
+            return "{\n" + ",\n".join(dict.map({ "\(nextIndent)\"\($0)\" : \($1._prettyPrint(indent, level + 1))"})) + "\n\(currentIndent)}"
             
         case .JSONNull:
             return "null"

--- a/Swifter/NSURL+Swifter.swift
+++ b/Swifter/NSURL+Swifter.swift
@@ -29,14 +29,14 @@ import Foundation
 extension NSURL {
 
     func URLByAppendingQueryString(queryString: String) -> NSURL {
-        if count(queryString.utf16) == 0 {
+        if queryString.utf16.count == 0 {
             return self
         }
 
-        var absoluteURLString = self.absoluteString!
+        var absoluteURLString = self.absoluteString
 
         if absoluteURLString.hasSuffix("?") {
-            absoluteURLString = absoluteURLString[0 ..< count(absoluteURLString.utf16)]
+            absoluteURLString = absoluteURLString[0 ..< absoluteURLString.utf16.count]
         }
 
         let URLString = absoluteURLString + (absoluteURLString.rangeOfString("?") != nil ? "&" : "?") + queryString

--- a/Swifter/SwifterAccountsClient.swift
+++ b/Swifter/SwifterAccountsClient.swift
@@ -38,7 +38,7 @@ internal class SwifterAccountsClient: SwifterClientProtocol {
     func get(path: String, baseURL: NSURL, parameters: Dictionary<String, AnyObject>, uploadProgress: SwifterHTTPRequest.UploadProgressHandler?, downloadProgress: SwifterHTTPRequest.DownloadProgressHandler?, success: SwifterHTTPRequest.SuccessHandler?, failure: SwifterHTTPRequest.FailureHandler?) -> SwifterHTTPRequest {
         let url = NSURL(string: path, relativeToURL: baseURL)
 
-        var stringifiedParameters = SwifterAccountsClient.convertDictionaryValuesToStrings(parameters)
+        let stringifiedParameters = SwifterAccountsClient.convertDictionaryValuesToStrings(parameters)
 
         let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter, requestMethod: SLRequestMethod.GET, URL: url, parameters: stringifiedParameters)
         socialRequest.account = self.credential!.account!
@@ -79,7 +79,7 @@ internal class SwifterAccountsClient: SwifterClientProtocol {
             }
         }
 
-        var stringifiedParameters = SwifterAccountsClient.convertDictionaryValuesToStrings(params)
+        let stringifiedParameters = SwifterAccountsClient.convertDictionaryValuesToStrings(params)
 
         let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter, requestMethod: SLRequestMethod.POST, URL: url, parameters: stringifiedParameters)
         socialRequest.account = self.credential!.account!
@@ -103,7 +103,7 @@ internal class SwifterAccountsClient: SwifterClientProtocol {
     class func convertDictionaryValuesToStrings(dictionary: Dictionary<String, AnyObject>) -> Dictionary<String, String> {
         var result = Dictionary<String, String>()
 
-        for (key, value: AnyObject) in dictionary {
+        for (key, value) in dictionary {
             result[key] = "\(value)"
         }
 

--- a/Swifter/SwifterAppOnlyClient.swift
+++ b/Swifter/SwifterAppOnlyClient.swift
@@ -86,7 +86,7 @@ internal class SwifterAppOnlyClient: SwifterClientProtocol  {
         let encodedSecret = secret.urlEncodedStringWithEncoding(NSUTF8StringEncoding)
         let bearerTokenCredentials = "\(encodedKey):\(encodedSecret)"
         if let data = bearerTokenCredentials.dataUsingEncoding(NSUTF8StringEncoding) {
-            return data.base64EncodedStringWithOptions(nil)
+            return data.base64EncodedStringWithOptions([])
         }
         return String()
     }

--- a/Swifter/SwifterAuth.swift
+++ b/Swifter/SwifterAuth.swift
@@ -61,7 +61,7 @@ public extension Swifter {
                 })
 
             let authorizeURL = NSURL(string: "/oauth/authorize", relativeToURL: self.apiURL)
-            let queryURL = NSURL(string: authorizeURL!.absoluteString! + "?oauth_token=\(token!.key)")
+            let queryURL = NSURL(string: authorizeURL!.absoluteString + "?oauth_token=\(token!.key)")
 
             #if os(iOS)
                 UIApplication.sharedApplication().openURL(queryURL!)
@@ -142,9 +142,7 @@ public extension Swifter {
 
         var parameters =  Dictionary<String, AnyObject>()
 
-        if let callbackURLString = callbackURL.absoluteString {
-            parameters["oauth_callback"] = callbackURLString
-        }
+        parameters["oauth_callback"] = callbackURL.absoluteString
 
         self.client.post(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             data, response in

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -525,7 +525,7 @@ public extension Swifter {
         let path = "followers/lookup.json"
 
         var parameters = Dictionary<String, AnyObject>()
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
@@ -542,7 +542,7 @@ public extension Swifter {
         var parameters = Dictionary<String, AnyObject>()
 
         let idStrings = ids.map { String($0) }
-        parameters["id"] = join(",", idStrings)
+        parameters["id"] = ",".join(idStrings)
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -57,7 +57,7 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFriendsIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDsWithID(id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, AnyObject>()
@@ -76,12 +76,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
     
-    public func getFriendsIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDsWithScreenName(screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, AnyObject>()
@@ -100,7 +100,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
@@ -114,7 +114,7 @@ public extension Swifter {
     
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFollowersIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDsWithID(id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, AnyObject>()
@@ -133,12 +133,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
     
-    public func getFollowersIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDsWithScreenName(screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, AnyObject>()
@@ -157,7 +157,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
@@ -181,7 +181,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
@@ -205,7 +205,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             
             }, failure: failure)
     }
@@ -401,7 +401,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFriendsListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsListWithID(id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -423,12 +423,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
 
             }, failure: failure)
     }
 
-    public func getFriendsListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsListWithScreenName(screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -450,7 +450,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
 
             }, failure: failure)
     }
@@ -462,7 +462,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFollowersListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersListWithID(id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -484,12 +484,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
 
             }, failure: failure)
     }
 
-    public func getFollowersListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersListWithScreenName(screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -511,7 +511,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
 
             }, failure: failure)
     }

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -57,12 +57,12 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFriendsIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         parameters["id"] = id
-
+        
         if cursor != nil {
             parameters["cursor"] = cursor!
         }
@@ -72,21 +72,21 @@ public extension Swifter {
         if count != nil {
             parameters["count"] = count!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
-
-    public func getFriendsIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    
+    public func getFriendsIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         parameters["screen_name"] = screenName
-
+        
         if cursor != nil {
             parameters["cursor"] = cursor!
         }
@@ -96,30 +96,30 @@ public extension Swifter {
         if count != nil {
             parameters["count"] = count!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
-
+    
     /*
     GET    followers/ids
-
+    
     Returns a cursored collection of user IDs for every user following the specified user.
-
+    
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 5,000 user IDs and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
-
+    
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFollowersIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDsWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         parameters["id"] = id
-
+        
         if cursor != nil {
             parameters["cursor"] = cursor!
         }
@@ -129,21 +129,21 @@ public extension Swifter {
         if count != nil {
             parameters["count"] = count!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
-
-    public func getFollowersIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    
+    public func getFollowersIDsWithScreenName(screenName: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         parameters["screen_name"] = screenName
-
+        
         if cursor != nil {
             parameters["cursor"] = cursor!
         }
@@ -153,23 +153,23 @@ public extension Swifter {
         if count != nil {
             parameters["count"] = count!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
-
+    
     /*
     GET    friendships/incoming
-
+    
     Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
     */
-    public func getFriendshipsIncomingWithCursor(cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsIncomingWithCursor(cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/incoming.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         if cursor != nil {
             parameters["cursor"] = cursor!
@@ -177,23 +177,23 @@ public extension Swifter {
         if stringifyIDs != nil {
             parameters["stringify_urls"] = stringifyIDs!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
-
+    
     /*
     GET    friendships/outgoing
-
+    
     Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
     */
-    public func getFriendshipsOutgoingWithCursor(cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsOutgoingWithCursor(cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/outgoing.json"
-
+        
         var parameters = Dictionary<String, AnyObject>()
         if cursor != nil {
             parameters["cursor"] = cursor!
@@ -201,12 +201,12 @@ public extension Swifter {
         if stringifyIDs != nil {
             parameters["stringify_urls"] = stringifyIDs!
         }
-
+        
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
-
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
+            
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
+            
             }, failure: failure)
     }
 

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -401,7 +401,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFriendsListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -423,12 +423,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
 
             }, failure: failure)
     }
 
-    public func getFriendsListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -450,7 +450,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
 
             }, failure: failure)
     }
@@ -462,7 +462,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFollowersListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersListWithID(id: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -484,12 +484,12 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
 
             }, failure: failure)
     }
 
-    public func getFollowersListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersListWithScreenName(screenName: String, cursor: Int? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -511,7 +511,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(users: json["users"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
+            success?(users: json["users"].array, previousCursor: json["previous_cursor"].string, nextCursor: json["next_cursor"].string)
 
             }, failure: failure)
     }

--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -115,7 +115,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
 
             let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.dataEncoding))
 
-            var nonOAuthParameters = self.parameters.filter { key, _ in !key.hasPrefix("oauth_") }
+            let nonOAuthParameters = self.parameters.filter { key, _ in !key.hasPrefix("oauth_") }
 
             if self.uploadData.count > 0 {
                 let boundary = "----------SwIfTeRhTtPrEqUeStBoUnDaRy"
@@ -123,7 +123,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
                 let contentType = "multipart/form-data; boundary=\(boundary)"
                 self.request!.setValue(contentType, forHTTPHeaderField:"Content-Type")
 
-                var body = NSMutableData();
+                let body = NSMutableData();
 
                 for dataUpload: DataUpload in self.uploadData {
                     let multipartData = SwifterHTTPRequest.mulipartContentWithBounday(boundary, data: dataUpload.data, fileName: dataUpload.fileName, parameterName: dataUpload.parameterName, mimeType: dataUpload.mimeType)
@@ -131,7 +131,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
                     body.appendData(multipartData)
                 }
 
-                for (key, value : AnyObject) in nonOAuthParameters {
+                for (key, value) in nonOAuthParameters {
                     body.appendData("\r\n--\(boundary)\r\n".dataUsingEncoding(NSUTF8StringEncoding)!)
                     body.appendData("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".dataUsingEncoding(NSUTF8StringEncoding)!)
                     body.appendData("\(value)".dataUsingEncoding(NSUTF8StringEncoding)!)
@@ -269,7 +269,8 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
     }
 
     class func responseErrorCode(data: NSData) -> Int? {
-        if let json: AnyObject = NSJSONSerialization.JSONObjectWithData(data, options: nil, error: nil) {
+        do {
+            let json: AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: [])
             if let dictionary = json as? NSDictionary {
                 if let errors = dictionary["errors"] as? [NSDictionary] {
                     if let code = errors.first?["code"] as? Int {
@@ -277,6 +278,7 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
                     }
                 }
             }
+        } catch _ {
         }
         return nil
     }

--- a/Swifter/SwifterHelp.swift
+++ b/Swifter/SwifterHelp.swift
@@ -116,7 +116,7 @@ public extension Swifter {
         let path = "application/rate_limit_status.json"
 
         var parameters = Dictionary<String, AnyObject>()
-        parameters["resources"] = join(",", resources)
+        parameters["resources"] = ",".join(resources)
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: [:], uploadProgress: nil, downloadProgress: nil, success: {
             json, response in

--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -334,7 +334,7 @@ public extension Swifter {
 
     Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
     */
-    public func getListsMembershipsWithUserID(userID: String, cursor: Int?, filterToOwnedLists: Bool?, success: ((lists: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembershipsWithUserID(userID: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSONValue]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -347,12 +347,11 @@ public extension Swifter {
             parameters["filter_to_owned_lists"] = filterToOwnedLists!
         }
 
-        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
-            json, response in
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: { (json: JSON, response) -> Void in
+            success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
+            return
+        }, failure: failure)
 
-            success?(lists: json["lists"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
-
-            }, failure: failure)
     }
 
     public func getListsMembershipsWithScreenName(screenName: String, cursor: Int?, filterToOwnedLists: Bool?, success: ((lists: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)?, failure: FailureHandler?) {
@@ -767,7 +766,7 @@ public extension Swifter {
         parameters["list_id"] = listID
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -790,7 +789,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         parameters["list_id"] = listID
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -816,7 +815,7 @@ public extension Swifter {
         parameters["owner_id"] = ownerID
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -840,7 +839,7 @@ public extension Swifter {
         var parameters = Dictionary<String, AnyObject>()
         parameters["slug"] = slug
         parameters["owner_id"] = ownerID
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -866,7 +865,7 @@ public extension Swifter {
         parameters["owner_screen_name"] = ownerScreenName
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -890,7 +889,7 @@ public extension Swifter {
         var parameters = Dictionary<String, AnyObject>()
         parameters["slug"] = slug
         parameters["owner_screen_name"] = ownerScreenName
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -1528,7 +1527,7 @@ public extension Swifter {
         parameters["list_id"] = listID
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
@@ -1544,7 +1543,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         parameters["list_id"] = listID
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
@@ -1562,7 +1561,7 @@ public extension Swifter {
         parameters["slug"] = slug
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         parameters["owner_screen_name"] = ownerScreenName
 
@@ -1580,7 +1579,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         parameters["slug"] = slug
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
         parameters["owner_screen_name"] = ownerScreenName
         
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
@@ -1599,7 +1598,7 @@ public extension Swifter {
         parameters["slug"] = slug
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         parameters["owner_id"] = ownerID
         
@@ -1617,7 +1616,7 @@ public extension Swifter {
         
         var parameters = Dictionary<String, AnyObject>()
         parameters["slug"] = slug
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
         parameters["owner_id"] = ownerID
         
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -125,7 +125,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
             authorizationParameters["oauth_token"] = self.credential!.accessToken!.key
         }
 
-        for (key, value: AnyObject) in parameters {
+        for (key, value) in parameters {
             if key.hasPrefix("oauth_") {
                 authorizationParameters.updateValue(value, forKey: key)
             }
@@ -138,7 +138,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
         authorizationParameters["oauth_signature"] = self.oauthSignatureForMethod(method, url: url, parameters: finalParameters, accessToken: self.credential?.accessToken)
 
         var authorizationParameterComponents = authorizationParameters.urlEncodedQueryStringWithEncoding(self.dataEncoding).componentsSeparatedByString("&") as [String]
-        authorizationParameterComponents.sort { $0 < $1 }
+        authorizationParameterComponents.sortInPlace { $0 < $1 }
 
         var headerComponents = [String]()
         for component in authorizationParameterComponents {
@@ -148,7 +148,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
             }
         }
 
-        return "OAuth " + join(", ", headerComponents)
+        return "OAuth " + ", ".join(headerComponents)
     }
 
     func oauthSignatureForMethod(method: String, url: NSURL, parameters: Dictionary<String, AnyObject>, accessToken token: SwifterCredential.OAuthAccessToken?) -> String {
@@ -162,18 +162,16 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
         let signingKey = "\(encodedConsumerSecret)&\(tokenSecret)"
 
         var parameterComponents = parameters.urlEncodedQueryStringWithEncoding(self.dataEncoding).componentsSeparatedByString("&") as [String]
-        parameterComponents.sort { $0 < $1 }
+        parameterComponents.sortInPlace { $0 < $1 }
 
-        let parameterString = join("&", parameterComponents)
+        let parameterString = "&".join(parameterComponents)
         let encodedParameterString = parameterString.urlEncodedStringWithEncoding(self.dataEncoding)
 
-        let encodedURL = url.absoluteString!.urlEncodedStringWithEncoding(self.dataEncoding)
+        let encodedURL = url.absoluteString.urlEncodedStringWithEncoding(self.dataEncoding)
 
         let signatureBaseString = "\(method)&\(encodedURL)&\(encodedParameterString)"
 
-        let signature = signatureBaseString.SHA1DigestWithKey(signingKey)
-
-        return signatureBaseString.SHA1DigestWithKey(signingKey).base64EncodedStringWithOptions(nil)
+        return signatureBaseString.SHA1DigestWithKey(signingKey).base64EncodedStringWithOptions([])
     }
     
 }

--- a/Swifter/SwifterSearch.swift
+++ b/Swifter/SwifterSearch.swift
@@ -71,10 +71,7 @@ public extension Swifter {
             switch (json["statuses"].array, json["search_metadata"].object) {
             case (let statuses, let searchMetadata):
                 success?(statuses: statuses, searchMetadata: searchMetadata)
-            default:
-                success?(statuses: nil, searchMetadata: nil)
             }
-
             }, failure: failure)
     }
     

--- a/Swifter/SwifterStreaming.swift
+++ b/Swifter/SwifterStreaming.swift
@@ -45,13 +45,13 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         if follow != nil {
-            parameters["follow"] = join(",", follow!)
+            parameters["follow"] = ",".join(follow!)
         }
         if track != nil {
-            parameters["track"] = join(",", track!)
+            parameters["track"] = ",".join(track!)
         }
         if locations != nil {
-            parameters["locations"] = join(",", locations!)
+            parameters["locations"] = ",".join(locations!)
         }
         if delimited != nil {
             parameters["delimited"] = delimited!
@@ -180,10 +180,10 @@ public extension Swifter {
             }
         }
         if track != nil {
-            parameters["track"] = join(",", track!)
+            parameters["track"] = ",".join(track!)
         }
         if locations != nil {
-            parameters["locations"] = join(",", locations!)
+            parameters["locations"] = ",".join(locations!)
         }
         if stringifyFriendIDs != nil {
             parameters["stringify_friend_ids"] = stringifyFriendIDs!

--- a/Swifter/SwifterTimelines.swift
+++ b/Swifter/SwifterTimelines.swift
@@ -87,7 +87,7 @@ public extension Swifter {
     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
     */
     public func getStatusesUserTimelineWithUserID(userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        var parameters: Dictionary<String, AnyObject> = ["user_id": userID]
+        let parameters: Dictionary<String, AnyObject> = ["user_id": userID]
 
         self.getTimelineAtPath("statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
@@ -101,7 +101,7 @@ public extension Swifter {
 
     Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow many users or follow users who tweet frequently.
     */
-    public func getStatusesHomeTimelineWithCount(_ count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesHomeTimelineWithCount(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         self.getTimelineAtPath("statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 

--- a/Swifter/SwifterTweets.swift
+++ b/Swifter/SwifterTweets.swift
@@ -143,7 +143,7 @@ public extension Swifter {
     - https://dev.twitter.com/docs/api/multiple-media-extended-entities
     */
     public func postStatusUpdate(status: String, inReplyToStatusID: String? = nil, lat: Double? = nil, long: Double? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        var path: String = "statuses/update.json"
+        let path: String = "statuses/update.json"
 
         var parameters = Dictionary<String, AnyObject>()
         parameters["status"] = status
@@ -174,7 +174,7 @@ public extension Swifter {
     }
 
     public func postStatusUpdate(status: String, media: NSData, inReplyToStatusID: String? = nil, lat: Double? = nil, long: Double? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        var path: String = "statuses/update_with_media.json"
+        let path: String = "statuses/update_with_media.json"
 
         var parameters = Dictionary<String, AnyObject>()
         parameters["status"] = status
@@ -322,7 +322,7 @@ public extension Swifter {
 
     This method offers similar data to GET statuses/retweets/:id and replaces API v1's GET statuses/:id/retweeted_by/ids method.
     */
-    public func getStatusesRetweetersWithID(id: String, cursor: Int? = nil, stringifyIDs: Bool? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesRetweetersWithID(id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: ((ids: [JSONValue]?, previousCursor: Int?, nextCursor: Int?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweeters/ids.json"
 
         var parameters = Dictionary<String, AnyObject>()
@@ -338,7 +338,7 @@ public extension Swifter {
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
 
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor"].integer, nextCursor: json["next_cursor"].integer)
+            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].integer, nextCursor: json["next_cursor_str"].integer)
 
             }, failure: failure)
     }
@@ -352,7 +352,7 @@ public extension Swifter {
         let path = "statuses/lookup.json"
 
         var parameters = Dictionary<String, AnyObject>()
-        parameters["id"] = join(",", tweetIDs)
+        parameters["id"] = ",".join(tweetIDs)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -187,7 +187,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         if imageData != nil {
-            parameters["image"] = imageData!.base64EncodedStringWithOptions(nil)
+            parameters["image"] = imageData!.base64EncodedStringWithOptions([])
         }
         if title != nil {
             parameters["title"] = title!
@@ -261,7 +261,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         if imageData != nil {
-            parameters["image"] = imageData!.base64EncodedStringWithOptions(nil)
+            parameters["image"] = imageData!.base64EncodedStringWithOptions([])
         }
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -449,7 +449,7 @@ public extension Swifter {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, AnyObject>()
-        parameters["screen_name"] = join(",", screenNames)
+        parameters["screen_name"] = ",".join(screenNames)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -470,7 +470,7 @@ public extension Swifter {
         var parameters = Dictionary<String, AnyObject>()
 
         let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = join(",", userIDStrings)
+        parameters["user_id"] = ",".join(userIDStrings)
 
         if includeEntities != nil {
             parameters["include_entities"] = includeEntities!
@@ -696,7 +696,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, AnyObject>()
         if imageData != nil {
-            parameters["banner"] = imageData!.base64EncodedStringWithOptions(nil)
+            parameters["banner"] = imageData!.base64EncodedStringWithOptions([])
         }
         if width != nil {
             parameters["width"] = width!

--- a/SwifterDemoMac/Info.plist
+++ b/SwifterDemoMac/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwifterDemoiOS/Info.plist
+++ b/SwifterDemoiOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -18,16 +18,6 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -38,6 +28,16 @@
 				<string>swifter</string>
 			</array>
 		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Cursors returned by methods in SwifterFollowers.swift are UInt64 but Swift.Int is 64– on arm64 and 32–bit on armv7 (32bit) devices. I just changed them all to strings, and made it possible for JSONValue.string to parse a number. (Not sure how well this implementation is, but it works for now)