### PR TITLE
fixed getUserStreamDelimited parameter

### DIFF
--- a/Swifter/SwifterStreaming.swift
+++ b/Swifter/SwifterStreaming.swift
@@ -159,7 +159,7 @@ public extension Swifter {
 
     Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func getUserStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromFollowedAccounts: Bool? = nil, includeReplies: Bool? = nil, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
+    public func getUserStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool? = nil, includeReplies: Bool? = nil, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
@@ -169,8 +169,8 @@ public extension Swifter {
         if stallWarnings != nil {
             parameters["stall_warnings"] = stallWarnings!
         }
-        if includeMessagesFromFollowedAccounts != nil {
-            if includeMessagesFromFollowedAccounts! {
+        if includeMessagesFromUserOnly != nil {
+            if includeMessagesFromUserOnly! {
                 parameters["with"] = "user"
             }
         }


### PR DESCRIPTION
As written in the [Twitter Documentation](https://dev.twitter.com/streaming/overview/request-parameters#with):
>The *with* parameter controls the types of messages delivered to User and Site Streams clients. 
>
>* The default for User Streams is *with=followings* which adds messages from accounts the user follows, equivalent to the user’s home timeline.

In conclusion, for User Streams:

* *with* = "user" to stream only messages from the user (associated with the stream);
* *with* = "following" to stream also messages from accounts the user (associated with the stream) follows;

Before this fix, the function *getUserStreamDelimited* was doing exactly the opposite of what it promised.