### PR TITLE
getListsOwnershipsWithUserID was using a POST request rather than a GET

### DIFF
--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -1647,7 +1647,7 @@ public extension Swifter {
             parameters["cursor"] = cursor!
         }
         
-        self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             json, response in
             
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)


### PR DESCRIPTION
When trying to use `getListsOwnershipsWithUserID` I was getting this error 

`HTTP Status 400: Bad Request, Response: {"errors":[{"code":86,"message":"This method requires a GET or HEAD."}]}`

Digging in, I found that `getListsOwnershipsWithUserID` was using a POST request rather than a GET.
