### PR TITLE
Replace `if variable != nil {}` with ??= operator

### DIFF
--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		8BF1D6861948BCC100E3AA64 /* SwifterAccountsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */; };
 		8BF1D6881948C11E00E3AA64 /* SwifterCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */; };
 		8BF1D6891948C11E00E3AA64 /* SwifterCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */; };
+		A17A694F1C78336200063DFD /* Operator+Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator+Swifter.swift */; };
+		A17A69501C78336300063DFD /* Operator+Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator+Swifter.swift */; };
 		A1DD65C51B618D7E0070E6FC /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A1DD65C41B618D7E0070E6FC /* Launch Screen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -121,7 +123,7 @@
 		8B548F581945325E00EE2927 /* SwifterAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAuth.swift; sourceTree = "<group>"; };
 		8B548F5B1945331D00EE2927 /* SwifterTimelines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTimelines.swift; sourceTree = "<group>"; };
 		8B552D29194643CF0052EB86 /* NSURL+Swifter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURL+Swifter.swift"; sourceTree = "<group>"; };
-		8B552D2C194695F80052EB86 /* SwifterStreaming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterStreaming.swift; sourceTree = "<group>"; };
+		8B552D2C194695F80052EB86 /* SwifterStreaming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwifterStreaming.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8B5EFF03195F064400B354F9 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8B5EFF04195F064400B354F9 /* AuthViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		8B5EFF05195F064400B354F9 /* TweetsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetsViewController.swift; sourceTree = "<group>"; };
@@ -137,8 +139,8 @@
 		8BA50EC61953828A00FB1829 /* SwifterAppOnlyClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAppOnlyClient.swift; sourceTree = "<group>"; };
 		8BC32D3C1955EEE100FF75A0 /* SwifterTrends.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTrends.swift; sourceTree = "<group>"; };
 		8BCB9328194B2E1200A998EA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		8BCF43161947450A00E63301 /* SwifterTweets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTweets.swift; sourceTree = "<group>"; };
-		8BCF431919475D3C00E63301 /* SwifterSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterSearch.swift; sourceTree = "<group>"; };
+		8BCF43161947450A00E63301 /* SwifterTweets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwifterTweets.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		8BCF431919475D3C00E63301 /* SwifterSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwifterSearch.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8BCF431C1947907300E63301 /* SwifterMessages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterMessages.swift; sourceTree = "<group>"; };
 		8BCF431F194798FB00E63301 /* SwifterFollowers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterFollowers.swift; sourceTree = "<group>"; };
 		8BCF43221947A6C800E63301 /* SwifterUsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterUsers.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 		8BF1D67E194889B900E3AA64 /* SwifterClientProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterClientProtocol.swift; sourceTree = "<group>"; };
 		8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAccountsClient.swift; sourceTree = "<group>"; };
 		8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterCredential.swift; sourceTree = "<group>"; };
+		A17A694D1C78333400063DFD /* Operator+Swifter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operator+Swifter.swift"; sourceTree = "<group>"; };
 		A1DD65C41B618D7E0070E6FC /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = "Launch Screen.storyboard"; path = "../Swifter/Launch Screen.storyboard"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -298,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				8B9F51471944A8DC00894629 /* Dictionary+Swifter.swift */,
+				A17A694D1C78333400063DFD /* Operator+Swifter.swift */,
 				8B552D29194643CF0052EB86 /* NSURL+Swifter.swift */,
 				8B9F514A1944A8DC00894629 /* String+Swifter.swift */,
 			);
@@ -507,6 +511,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A17A694F1C78336200063DFD /* Operator+Swifter.swift in Sources */,
 				8BCF43291947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43261947CABA00E63301 /* SwifterSuggested.swift in Sources */,
 				8B116AF1194601970019A4DC /* SwifterHTTPRequest.swift in Sources */,
@@ -541,6 +546,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A17A69501C78336300063DFD /* Operator+Swifter.swift in Sources */,
 				8BCF432A1947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43271947CABA00E63301 /* SwifterSuggested.swift in Sources */,
 				8B116AF2194601970019A4DC /* SwifterHTTPRequest.swift in Sources */,

--- a/Swifter/Operator+Swifter.swift
+++ b/Swifter/Operator+Swifter.swift
@@ -1,0 +1,18 @@
+//
+//  Operator+Swifter.swift
+//  Swifter
+//
+//  Created by Andy Liang on 2016-02-19.
+//  Copyright © 2016 Matt Donnelly. All rights reserved.
+//
+
+import Foundation
+
+/// If `rhs` is not `nil`, assign it to `lhs`.
+infix operator ??= { associativity right precedence 90 assignment } // matches other assignment operators
+
+/// If `rhs` is not `nil`, assign it to `lhs`.
+func ??=<T>(inout lhs: T?, rhs: T?) {
+    guard let rhs = rhs else { return }
+    lhs = rhs
+}

--- a/Swifter/String+Swifter.swift
+++ b/Swifter/String+Swifter.swift
@@ -70,8 +70,8 @@ extension String {
             scanner.scanUpToString("&", intoString: &value)
             scanner.scanString("&", intoString: nil)
 
-            if key != nil && value != nil {
-                parameters.updateValue(value! as String, forKey: key! as String)
+            if let key = key as? String, let value = value as? String {
+                parameters.updateValue(value, forKey: key)
             }
         }
         

--- a/Swifter/SwifterAppOnlyClient.swift
+++ b/Swifter/SwifterAppOnlyClient.swift
@@ -68,8 +68,7 @@ internal class SwifterAppOnlyClient: SwifterClientProtocol  {
 
         if let bearerToken = self.credential?.accessToken?.key {
             request.headers = ["Authorization": "Bearer \(bearerToken)"];
-        }
-        else {
+        } else {
             let basicCredentials = SwifterAppOnlyClient.base64EncodedCredentialsWithKey(self.consumerKey, secret: self.consumerSecret)
             request.headers = ["Authorization": "Basic \(basicCredentials)"];
             request.encodeParameters = true

--- a/Swifter/SwifterFavorites.swift
+++ b/Swifter/SwifterFavorites.swift
@@ -38,18 +38,11 @@ public extension Swifter {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
+        parameters["count"] ??= count
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
-
             success?(statuses: json.array)
             }, failure: failure)
     }
@@ -59,16 +52,9 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
+        parameters["count"] ??= count
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -80,16 +66,9 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
+        parameters["count"] ??= count
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -108,10 +87,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -130,10 +106,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(status: json.object)

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -32,11 +32,11 @@ public extension Swifter {
 
     Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from. Use POST friendships/update to set the "no retweets" status for a given user account on behalf of the current user.
     */
-    public func getFriendshipsNoRetweetsIDsWithStringifyIDs(stringifyIDs: Bool? = nil, success: ((ids: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsNoRetweetsIDsWithStringifyIDs(stringifyIDs: Bool = true, success: ((ids: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/no_retweets/ids.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["stringify_ids"] = stringifyIDs!
+        parameters["stringify_ids"] = stringifyIDs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json.array)
@@ -58,18 +58,11 @@ public extension Swifter {
         
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
+        parameters["count"] ??= count
         
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        
-        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             }, failure: failure)
     }
@@ -79,18 +72,11 @@ public extension Swifter {
         
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
+        parameters["count"] ??= count
         
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        
-        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
             }, failure: failure)
     }
@@ -109,16 +95,9 @@ public extension Swifter {
         
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-        
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
+        parameters["count"] ??= count
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -130,16 +109,9 @@ public extension Swifter {
         
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-        
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
+        parameters["count"] ??= count
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -155,12 +127,8 @@ public extension Swifter {
         let path = "friendships/incoming.json"
         
         var parameters = Dictionary<String, Any>()
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_urls"] = stringifyIDs!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -176,12 +144,8 @@ public extension Swifter {
         let path = "friendships/outgoing.json"
         
         var parameters = Dictionary<String, Any>()
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_urls"] = stringifyIDs!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -202,10 +166,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if follow != nil {
-            parameters["follow"] = follow!
-        }
+        parameters["follow"] ??= follow
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -217,10 +178,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if follow != nil {
-            parameters["follow"] = follow!
-        }
+        parameters["follow"] ??= follow
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -268,13 +226,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if device != nil {
-            parameters["device"] = device!
-        }
-        if retweets != nil {
-            parameters["retweets"] = retweets!
-        }
+        parameters["device"] ??= device
+        parameters["retweets"] ??= retweets
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -286,13 +239,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if device != nil {
-            parameters["device"] = device!
-        }
-        if retweets != nil {
-            parameters["retweets"] = retweets!
-        }
+        parameters["device"] ??= device
+        parameters["retweets"] ??= retweets
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -304,36 +252,26 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func getFriendshipsShowWithSourceID(sourceID: String? = nil, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsShowWithSourceID(sourceID: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["source_id"] = sourceID!
-
-        if targetID != nil {
-            parameters["target_id"] = targetID!
-        }
-        else if targetScreenName != nil {
-            parameters["targetScreenName"] = targetScreenName!
-        }
+        parameters["source_id"] = sourceID
+        parameters["target_id"] ??= targetID
+        parameters["targetScreenName"] ??= targetScreenName
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
             }, failure: failure)
     }
 
-    public func getFriendshipsShowWithSourceScreenName(sourceScreenName: String? = nil, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsShowWithSourceScreenName(sourceScreenName: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["source_screen_name"] = sourceScreenName!
-
-        if targetID != nil {
-            parameters["target_id"] = targetID!
-        }
-        else if targetScreenName != nil {
-            parameters["targetScreenName"] = targetScreenName!
-        }
+        parameters["source_screen_name"] = sourceScreenName
+        parameters["target_id"] ??= targetID
+        parameters["targetScreenName"] ??= targetScreenName
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -352,19 +290,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if includeUserEntities != nil {
-            parameters["include_user_entities"] = includeUserEntities!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["count"] ??= count
+        parameters["skip_status"] ??= skipStatus
+        parameters["include_user_entities"] ??= includeUserEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -376,19 +305,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if includeUserEntities != nil {
-            parameters["include_user_entities"] = includeUserEntities!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["count"] ??= count
+        parameters["skip_status"] ??= skipStatus
+        parameters["include_user_entities"] ??= includeUserEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -408,19 +328,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if includeUserEntities != nil {
-            parameters["include_user_entities"] = includeUserEntities!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["count"] ??= count
+        parameters["skip_status"] ??= skipStatus
+        parameters["include_user_entities"] ??= includeUserEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -432,19 +343,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if includeUserEntities != nil {
-            parameters["include_user_entities"] = includeUserEntities!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["count"] ??= count
+        parameters["skip_status"] ??= skipStatus
+        parameters["include_user_entities"] ??= includeUserEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)

--- a/Swifter/SwifterHTTPRequest.swift
+++ b/Swifter/SwifterHTTPRequest.swift
@@ -266,8 +266,8 @@ public class SwifterHTTPRequest: NSObject, NSURLConnectionDataDelegate {
     class func stringWithData(data: NSData, encodingName: String?) -> String {
         var encoding: UInt = NSUTF8StringEncoding
 
-        if encodingName != nil {
-            let encodingNameString = encodingName! as NSString as CFStringRef
+        if let encodingName = encodingName {
+            let encodingNameString = encodingName as NSString as CFStringRef
             encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding(encodingNameString))
 
             if encoding == UInt(kCFStringEncodingInvalidId) {

--- a/Swifter/SwifterHelp.swift
+++ b/Swifter/SwifterHelp.swift
@@ -37,8 +37,7 @@ public extension Swifter {
     public func getHelpConfigurationWithSuccess(success: ((config: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "help/configuration.json"
 
-        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: [:], success: {
-            json, _ in
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: [:], success: { json, _ in
             success?(config: json.object)
             }, failure: failure)
     }

--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -40,9 +40,7 @@ public extension Swifter {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
-        if reverse != nil {
-            parameters["reverse"] = reverse!
-        }
+        parameters["reverse"] ??= reverse
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json.array)
@@ -54,10 +52,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["userID"] = userID
-
-        if reverse != nil {
-            parameters["reverse"] = reverse!
-        }
+        parameters["reverse"] ??= reverse
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json.array)
@@ -69,10 +64,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if reverse != nil {
-            parameters["reverse"] = reverse!
-        }
+        parameters["reverse"] ??= reverse
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json.array)
@@ -90,22 +82,11 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
         parameters["owner_screen_name"] = ownerScreenName
-
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if includeRTs != nil {
-            parameters["include_rts"] = includeRTs!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
+        parameters["include_rts"] ??= includeRTs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -118,22 +99,11 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
         parameters["owner_id"] = ownerID
-
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if includeRTs != nil {
-            parameters["include_rts"] = includeRTs!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
+        parameters["include_rts"] ??= includeRTs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -146,22 +116,11 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
         parameters["owner_screen_name"] = ownerScreenName
-
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if includeRTs != nil {
-            parameters["include_rts"] = includeRTs!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
+        parameters["include_rts"] ??= includeRTs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -174,22 +133,11 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
         parameters["owner_id"] = ownerID
-
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if includeRTs != nil {
-            parameters["include_rts"] = includeRTs!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
+        parameters["include_rts"] ??= includeRTs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -287,13 +235,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if filterToOwnedLists != nil {
-            parameters["filter_to_owned_lists"] = filterToOwnedLists!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["filter_to_owned_lists"] ??= filterToOwnedLists
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -307,12 +250,8 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
 
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if filterToOwnedLists != nil {
-            parameters["filter_to_owned_lists"] = filterToOwnedLists!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["filter_to_owned_lists"] ??= filterToOwnedLists
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -330,18 +269,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        if ownerScreenName != nil {
-            parameters["owner_screen_name"] = ownerScreenName!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -354,18 +285,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        if ownerID != nil {
-            parameters["owner_id"] = ownerID!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_id"] ??= ownerID
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -378,18 +301,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        if ownerScreenName != nil {
-            parameters["owner_screen_name"] = ownerScreenName!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -402,18 +317,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        if ownerID != nil {
-            parameters["owner_id"] = ownerID!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_id"] ??= ownerID
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -486,12 +393,8 @@ public extension Swifter {
         parameters["list_id"] = listID
         parameters["user_id"] = userID
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -505,12 +408,8 @@ public extension Swifter {
         parameters["list_id"] = listID
         parameters["screen_name"] = screenName
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -525,12 +424,8 @@ public extension Swifter {
         parameters["owner_id"] = ownerID
         parameters["user_id"] = userID
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -545,12 +440,8 @@ public extension Swifter {
         parameters["owner_id"] = ownerID
         parameters["screen_name"] = screenName
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -565,12 +456,8 @@ public extension Swifter {
         parameters["owner_screen_name"] = ownerScreenName
         parameters["user_id"] = userID
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -585,12 +472,8 @@ public extension Swifter {
         parameters["owner_screen_name"] = ownerScreenName
         parameters["screen_name"] = screenName
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -653,12 +536,8 @@ public extension Swifter {
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -672,12 +551,8 @@ public extension Swifter {
         parameters["list_id"] = listID
         parameters["screen_name"] = screenNames.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -694,12 +569,8 @@ public extension Swifter {
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -714,12 +585,8 @@ public extension Swifter {
         parameters["owner_id"] = ownerID
         parameters["screen_name"] = screenNames.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -736,12 +603,8 @@ public extension Swifter {
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -756,12 +619,8 @@ public extension Swifter {
         parameters["owner_screen_name"] = ownerScreenName
         parameters["screen_name"] = screenNames.joinWithSeparator(",")
 
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -779,13 +638,8 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -798,13 +652,8 @@ public extension Swifter {
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -818,13 +667,8 @@ public extension Swifter {
         parameters["slug"] = slug
         parameters["owner_id"] = ownerID
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -838,13 +682,8 @@ public extension Swifter {
         parameters["slug"] = slug
         parameters["owner_id"] = ownerID
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -858,13 +697,8 @@ public extension Swifter {
         parameters["slug"] = slug
         parameters["owner_screen_name"] = ownerScreenName
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -883,13 +717,8 @@ public extension Swifter {
         parameters["slug"] = slug
         parameters["owner_screen_name"] = ownerScreenName
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -901,18 +730,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        if ownerScreenName != nil {
-            parameters["owner_screen_name"] = ownerScreenName!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -925,18 +746,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        if ownerID != nil {
-            parameters["owner_id"] = ownerID!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_id"] ??= ownerID
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -949,18 +762,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        if ownerScreenName != nil {
-            parameters["owner_screen_name"] = ownerScreenName!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -973,18 +778,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        if ownerID != nil {
-            parameters["owner_id"] = ownerID!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["owner_id"] ??= ownerID
+        parameters["cursor"] ??= cursor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -1091,80 +888,44 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func postListsUpdateWithListID(listID: String, name: String?, publicMode: Bool?, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdateWithListID(listID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-
-        if name != nil {
-            parameters["name"] = name!
-        }
-        if publicMode != nil {
-            if publicMode! {
-                parameters["mode"] = "public"
-            }
-            else {
-                parameters["mode"] = "private"
-            }
-        }
-        if description != nil {
-            parameters["description"] = description!
-        }
+        parameters["name"] ??= name
+        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["description"] ??= description
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(list: json.object)
             }, failure: failure)
     }
 
-    public func postListsUpdateWithSlug(slug: String, ownerID: String, name: String?, publicMode: Bool?, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdateWithSlug(slug: String, ownerID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
         parameters["owner_id"] = ownerID
-
-        if name != nil {
-            parameters["name"] = name!
-        }
-        if publicMode != nil {
-            if publicMode! {
-                parameters["mode"] = "public"
-            }
-            else {
-                parameters["mode"] = "private"
-            }
-        }
-        if description != nil {
-            parameters["description"] = description!
-        }
+        parameters["name"] ??= name
+        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["description"] ??= description
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(list: json.object)
             }, failure: failure)
     }
 
-    public func postListsUpdateWithSlug(slug: String, ownerScreenName: String, name: String?, publicMode: Bool?, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdateWithSlug(slug: String, ownerScreenName: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
         parameters["owner_screen_name"] = ownerScreenName
-
-        if name != nil {
-            parameters["name"] = name!
-        }
-        if publicMode != nil {
-            if publicMode! {
-                parameters["mode"] = "public"
-            }
-            else {
-                parameters["mode"] = "private"
-            }
-        }
-        if description != nil {
-            parameters["description"] = description!
-        }
+        parameters["name"] ??= name
+        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["description"] ??= description
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -1176,23 +937,13 @@ public extension Swifter {
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsCreateWithName(name: String, publicMode: Bool?, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsCreateWithName(name: String, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSONValue>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["name"] = name
-
-        if publicMode != nil {
-            if publicMode! {
-                parameters["mode"] = "public"
-            }
-            else {
-                parameters["mode"] = "private"
-            }
-        }
-        if description != nil {
-            parameters["description"] = description!
-        }
+        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["description"] ??= description
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -1249,13 +1000,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["count"] ??= count
+        parameters["cursor"] ??= cursor
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -1268,13 +1014,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["count"] ??= count
+        parameters["cursor"] ??= cursor
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -1320,10 +1061,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
-
         parameters["owner_screen_name"] = ownerScreenName
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
@@ -1352,7 +1091,6 @@ public extension Swifter {
 
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
-
         parameters["owner_id"] = ownerID
         
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
@@ -1383,13 +1121,8 @@ public extension Swifter {
         
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-        
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["count"] ??= count
+        parameters["cursor"] ??= cursor
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)

--- a/Swifter/SwifterMessages.swift
+++ b/Swifter/SwifterMessages.swift
@@ -36,21 +36,11 @@ public extension Swifter {
         let path = "direct_messages.json"
 
         var parameters = Dictionary<String, Any>()
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(messages: json.array)
@@ -66,21 +56,11 @@ public extension Swifter {
         let path = "direct_messages/sent.json"
 
         var parameters = Dictionary<String, Any>()
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if page != nil {
-            parameters["page"] = page!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["count"] ??= count
+        parameters["page"] ??= page
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(messages: json.array)
@@ -94,9 +74,7 @@ public extension Swifter {
     */
     public func getDirectMessagesShowWithID(id: String, success: ((messages: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
+        let parameters: [String: Any] = ["id" : id]
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(messages: json.array)
@@ -113,11 +91,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-
+        parameters["include_entities"] ??= includeEntities
+        
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(messages: json.object)
             }, failure: failure)

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -119,7 +119,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
         authorizationParameters["oauth_timestamp"] = String(Int(NSDate().timeIntervalSince1970))
         authorizationParameters["oauth_nonce"] = NSUUID().UUIDString
 
-        authorizationParameters["oauth_token"] ??= self.credential!.accessToken?.key
+        authorizationParameters["oauth_token"] ??= self.credential?.accessToken?.key
 
         for (key, value) in parameters where key.hasPrefix("oauth_") {
             authorizationParameters.updateValue(value, forKey: key)

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -119,14 +119,10 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
         authorizationParameters["oauth_timestamp"] = String(Int(NSDate().timeIntervalSince1970))
         authorizationParameters["oauth_nonce"] = NSUUID().UUIDString
 
-        if self.credential?.accessToken != nil {
-            authorizationParameters["oauth_token"] = self.credential!.accessToken!.key
-        }
+        authorizationParameters["oauth_token"] ??= self.credential!.accessToken?.key
 
-        for (key, value): (String, Any) in parameters {
-            if key.hasPrefix("oauth_") {
-                authorizationParameters.updateValue(value, forKey: key)
-            }
+        for (key, value) in parameters where key.hasPrefix("oauth_") {
+            authorizationParameters.updateValue(value, forKey: key)
         }
 
         let combinedParameters = authorizationParameters +| parameters
@@ -150,10 +146,7 @@ internal class SwifterOAuthClient: SwifterClientProtocol  {
     }
 
     func oauthSignatureForMethod(method: HTTPMethodType, url: NSURL, parameters: Dictionary<String, Any>, accessToken token: SwifterCredential.OAuthAccessToken?) -> String {
-        var tokenSecret: NSString = ""
-        if token != nil {
-            tokenSecret = token!.secret.urlEncodedStringWithEncoding(self.dataEncoding)
-        }
+        let tokenSecret: NSString = token?.secret.urlEncodedStringWithEncoding(self.dataEncoding) ?? ""
 
         let encodedConsumerSecret = self.consumerSecret.urlEncodedStringWithEncoding(self.dataEncoding)
 

--- a/Swifter/SwifterPlaces.swift
+++ b/Swifter/SwifterPlaces.swift
@@ -54,18 +54,10 @@ public extension Swifter {
         parameters["lat"] = lat
         parameters["long"] = long
 
-        if accuracy != nil {
-            parameters["accuracy"] = accuracy!
-        }
-        if granularity != nil {
-            parameters["granularity"] = granularity!
-        }
-        if maxResults != nil {
-            parameters["max_results"] = maxResults!
-        }
-        if callback != nil {
-            parameters["callback"] = callback!
-        }
+        parameters["accuracy"] ??= accuracy
+        parameters["granularity"] ??= granularity
+        parameters["max_results"] ??= maxResults
+        parameters["callback"] ??= callback
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(place: json.object)
@@ -87,37 +79,16 @@ public extension Swifter {
         let path = "geo/search.json"
 
         var parameters = Dictionary<String, Any>()
-
-        if lat != nil {
-            parameters["lat"] = lat!
-        }
-        if long != nil {
-            parameters["long"] = long!
-        }
-        if query != nil {
-            parameters["query"] = query!
-        }
-        if ipAddress != nil {
-            parameters["ipAddress"] = ipAddress!
-        }
-        if accuracy != nil {
-            parameters["accuracy"] = accuracy!
-        }
-        if granularity != nil {
-            parameters["granularity"] = granularity!
-        }
-        if maxResults != nil {
-            parameters["max_results"] = maxResults!
-        }
-        if containedWithin != nil {
-            parameters["contained_within"] = containedWithin!
-        }
-        if attributeStreetAddress != nil {
-            parameters["attribute:street_address"] = attributeStreetAddress
-        }
-        if callback != nil {
-            parameters["callback"] = callback!
-        }
+        parameters["lat"] ??= lat
+        parameters["long"] ??= long
+        parameters["query"] ??= query
+        parameters["ipAddress"] ??= ipAddress
+        parameters["accuracy"] ??= accuracy
+        parameters["granularity"] ??= granularity
+        parameters["max_results"] ??= maxResults
+        parameters["contained_within"] ??= containedWithin
+        parameters["attribute:street_address"] ??= attributeStreetAddress
+        parameters["callback"] ??= callback
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(places: json.array)
@@ -140,18 +111,12 @@ public extension Swifter {
         parameters["lat"] = lat
         parameters["long"] = long
         parameters["name"] = name
+        
+        parameters["contained_within"] ??= containedWithin
+        parameters["attribute:street_address"] ??= attributeStreetAddress
+        parameters["callback"] ??= callback
 
-        if containedWithin != nil {
-            parameters["contained_within"] = containedWithin!
-        }
-        if attributeStreetAddress != nil {
-            parameters["attribute:street_address"] = attributeStreetAddress
-        }
-        if callback != nil {
-            parameters["callback"] = callback!
-        }
-
-        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
+        self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(places: json.array)
             }, failure: failure)
     }

--- a/Swifter/SwifterSearch.swift
+++ b/Swifter/SwifterSearch.swift
@@ -33,44 +33,19 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["q"] = q
-
-        if geocode != nil {
-            parameters["geocode"] = geocode!
-        }
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
-        if locale != nil {
-            parameters["locale"] = locale!
-        }
-        if resultType != nil {
-            parameters["result_type"] = resultType!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if until != nil {
-            parameters["until"] = until!
-        }
-        if sinceID != nil {
-            parameters["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            parameters["max_id"] = maxID!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if callback != nil {
-            parameters["callback"] = callback!
-        }
+        parameters["geocode"] ??= geocode
+        parameters["lang"] ??= lang
+        parameters["locale"] ??= locale
+        parameters["result_type"] ??= resultType
+        parameters["count"] ??= count
+        parameters["until"] ??= until
+        parameters["since_id"] ??= sinceID
+        parameters["max_id"] ??= maxID
+        parameters["include_entities"] ??= includeEntities
+        parameters["callback"] ??= callback
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
-            switch (json["statuses"].array, json["search_metadata"].object) {
-            case (let statuses, let searchMetadata):
-                success?(statuses: statuses, searchMetadata: searchMetadata)
-            }
-
+            success?(statuses: json["statuses"].array, searchMetadata: json["search_metadata"].object)
             }, failure: failure)
     }
     

--- a/Swifter/SwifterStreaming.swift
+++ b/Swifter/SwifterStreaming.swift
@@ -44,27 +44,13 @@ public extension Swifter {
         let path = "statuses/filter.json"
 
         var parameters = Dictionary<String, Any>()
-        if follow != nil {
-            parameters["follow"] = follow!.joinWithSeparator(",")
-        }
-        if track != nil {
-            parameters["track"] = track!.joinWithSeparator(",")
-        }
-        if locations != nil {
-            parameters["locations"] = locations!.joinWithSeparator(",")
-        }
-        if delimited != nil {
-            parameters["delimited"] = delimited!
-        }
-        if stallWarnings != nil {
-            parameters["stall_warnings"] = stallWarnings!
-        }
-        if filter_level != nil {
-            parameters["filter_level"] = filter_level!
-        }
-        if language != nil {
-            parameters["language"] = language!.joinWithSeparator(",")
-        }
+        parameters["delimited"] ??= delimited
+        parameters["stall_warnings"] ??= stallWarnings
+        parameters["filter_level"] ??= filter_level
+        parameters["language"] ??= language?.joinWithSeparator(",")
+        parameters["follow"] ??= follow?.joinWithSeparator(",")
+        parameters["track"] ??= track?.joinWithSeparator(",")
+        parameters["locations"] ??= locations?.joinWithSeparator(",")
 
         return self.postJSONWithPath(path, baseURL: self.streamURL, parameters: parameters, downloadProgress: { json, _ in
             if let stallWarning = json["warning"].object {
@@ -87,18 +73,10 @@ public extension Swifter {
         let path = "statuses/sample.json"
 
         var parameters = Dictionary<String, Any>()
-        if delimited != nil {
-            parameters["delimited"] = delimited!
-        }
-        if stallWarnings != nil {
-            parameters["stall_warnings"] = stallWarnings!
-        }
-        if filter_level != nil {
-            parameters["filter_level"] = filter_level!
-        }
-        if language != nil {
-            parameters["language"] = language!.joinWithSeparator(",")
-        }
+        parameters["delimited"] ??= delimited
+        parameters["stall_warnings"] ??= stallWarnings
+        parameters["filter_level"] ??= filter_level
+        parameters["language"] ??= language?.joinWithSeparator(",")
 
         return self.getJSONWithPath(path, baseURL: self.streamURL, parameters: parameters, downloadProgress: { json, _ in
             if let stallWarning = json["warning"].object {
@@ -123,21 +101,11 @@ public extension Swifter {
         let path = "statuses/firehose.json"
 
         var parameters = Dictionary<String, Any>()
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if delimited != nil {
-            parameters["delimited"] = delimited!
-        }
-        if stallWarnings != nil {
-            parameters["stall_warnings"] = stallWarnings!
-        }
-        if filter_level != nil {
-            parameters["filter_level"] = filter_level!
-        }
-        if language != nil {
-            parameters["language"] = language!.joinWithSeparator(",")
-        }
+        parameters["count"] ??= count
+        parameters["delimited"] ??= delimited
+        parameters["stall_warnings"] ??= stallWarnings
+        parameters["filter_level"] ??= filter_level
+        parameters["language"] ??= language?.joinWithSeparator(",")
 
         return self.getJSONWithPath(path, baseURL: self.streamURL, parameters: parameters, downloadProgress: { json, _ in
             if let stallWarning = json["warning"].object {
@@ -156,37 +124,19 @@ public extension Swifter {
 
     Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func getUserStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool? = nil, includeReplies: Bool? = nil, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
+    public func getUserStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
-        if delimited != nil {
-            parameters["delimited"] = delimited!
-        }
-        if stallWarnings != nil {
-            parameters["stall_warnings"] = stallWarnings!
-        }
-        if includeMessagesFromUserOnly != nil && includeMessagesFromUserOnly! {
-            parameters["with"] = "user"
-        }
-        if includeReplies != nil && includeReplies! {
-            parameters["replies"] = "all"
-        }
-        if track != nil {
-            parameters["track"] = track!.joinWithSeparator(",")
-        }
-        if locations != nil {
-            parameters["locations"] = locations!.joinWithSeparator(",")
-        }
-        if stringifyFriendIDs != nil {
-            parameters["stringify_friend_ids"] = stringifyFriendIDs!
-        }
-        if filter_level != nil {
-            parameters["filter_level"] = filter_level!
-        }
-        if language != nil {
-            parameters["language"] = language!.joinWithSeparator(",")
-        }
+        parameters["delimited"] ??= delimited
+        parameters["stall_warnings"] ??= stallWarnings
+        parameters["filter_level"] ??= filter_level
+        parameters["language"] ??= language?.joinWithSeparator(",")
+        parameters["stringify_friend_ids"] ??= stringifyFriendIDs
+        parameters["track"] ??= track?.joinWithSeparator(",")
+        parameters["locations"] ??= locations?.joinWithSeparator(",")
+        parameters["with"] ??= includeMessagesFromUserOnly ? "user" : nil
+        parameters["replies"] ??= includeReplies ? "all" : nil
 
         return self.getJSONWithPath(path, baseURL: self.userStreamURL, parameters: parameters, downloadProgress: { json, _ in
             if let stallWarning = json["warning"].object {
@@ -205,25 +155,15 @@ public extension Swifter {
 
     Streams messages for a set of users, as described in Site streams https://dev.twitter.com/docs/streaming-apis/streams/site
     */
-    public func getSiteStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool? = nil, includeReplies: Bool? = nil, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
+    public func getSiteStreamDelimited(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> SwifterHTTPRequest {
         let path = "site.json"
 
         var parameters = Dictionary<String, Any>()
-        if delimited != nil {
-            parameters["delimited"] = delimited!
-        }
-        if stallWarnings != nil {
-            parameters["stall_warnings"] = stallWarnings!
-        }
-        if restrictToUserMessages != nil && restrictToUserMessages! {
-            parameters["with"] = "user"
-        }
-        if includeReplies != nil && includeReplies! {
-            parameters["replies"] = "all"
-        }
-        if stringifyFriendIDs != nil {
-            parameters["stringify_friend_ids"] = stringifyFriendIDs!
-        }
+        parameters["delimited"] ??= delimited
+        parameters["stall_warnings"] ??= stallWarnings
+        parameters["stringify_friend_ids"] ??= stringifyFriendIDs
+        parameters["with"] ??= restrictToUserMessages ? "user" : nil
+        parameters["replies"] ??= includeReplies ? "all" : nil
 
         return self.getJSONWithPath(path, baseURL: self.streamURL, parameters: parameters, downloadProgress: { json, _ in
             stallWarningHandler?(code: json["warning"]["code"].string, message: json["warning"]["message"].string, percentFull: json["warning"]["percent_full"].integer)

--- a/Swifter/SwifterSuggested.swift
+++ b/Swifter/SwifterSuggested.swift
@@ -38,9 +38,7 @@ public extension Swifter {
         let path = "users/suggestions/\(slug).json"
 
         var parameters = Dictionary<String, Any>()
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
+        parameters["lang"] ??= lang
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -56,9 +54,7 @@ public extension Swifter {
         let path = "users/suggestions.json"
 
         var parameters = Dictionary<String, Any>()
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
+        parameters["lang"] ??= lang
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)

--- a/Swifter/SwifterTimelines.swift
+++ b/Swifter/SwifterTimelines.swift
@@ -30,25 +30,12 @@ public extension Swifter {
     // Convenience method
     private func getTimelineAtPath(path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         var params = parameters
-
-        if count != nil {
-            params["count"] = count!
-        }
-        if sinceID != nil {
-            params["since_id"] = sinceID!
-        }
-        if maxID != nil {
-            params["max_id"] = maxID!
-        }
-        if trimUser != nil {
-            params["trim_user"] = Int(trimUser!)
-        }
-        if contributorDetails != nil {
-            params["contributor_details"] = Int(!contributorDetails!)
-        }
-        if includeEntities != nil {
-            params["include_entities"] = Int(includeEntities!)
-        }
+        params["count"] ??= count
+        params["since_id"] ??= sinceID
+        params["max_id"] ??= maxID
+        params["trim_user"] ??= trimUser
+        params["contributor_details"] ??= contributorDetails
+        params["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: params, success: { json, _ in
             success?(statuses: json.array)

--- a/Swifter/SwifterTrends.swift
+++ b/Swifter/SwifterTrends.swift
@@ -19,17 +19,12 @@ public extension Swifter {
 
     This information is cached for 5 minutes. Requesting more frequently than that will not return any more data, and will count against your rate limit usage.
     */
-    public func getTrendsPlaceWithWOEID(id: String, excludeHashtags: Bool? = nil, success: ((trends: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsPlaceWithWOEID(id: String, excludeHashtags: Bool = false, success: ((trends: [JSONValue]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "trends/place.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if excludeHashtags != nil {
-            if excludeHashtags! {
-                parameters["exclude"] = "hashtags"
-            }
-        }
+        parameters["exclude"] = excludeHashtags ? "hashtags" : nil
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in            
             success?(trends: json.array)

--- a/Swifter/SwifterTweets.swift
+++ b/Swifter/SwifterTweets.swift
@@ -36,12 +36,8 @@ public extension Swifter {
         let path = "statuses/retweets/\(id).json"
 
         var parameters = Dictionary<String, Any>()
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
-        }
+        parameters["count"] ??= count
+        parameters["trim_user"] ??= trimUser
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
@@ -72,18 +68,10 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
-        }
-        if includeMyRetweet != nil {
-            parameters["include_my_retweet"] = includeMyRetweet!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["count"] ??= count
+        parameters["trim_user"] ??= trimUser
+        parameters["include_my_retweet"] ??= includeMyRetweet
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -99,9 +87,7 @@ public extension Swifter {
         let path = "statuses/destroy/\(id).json"
 
         var parameters = Dictionary<String, Any>()
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
-        }
+        parameters["trim_user"] ??= trimUser
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -130,29 +116,25 @@ public extension Swifter {
     - https://dev.twitter.com/notifications/multiple-media-entities-in-tweets
     - https://dev.twitter.com/docs/api/multiple-media-extended-entities
     */
-    public func postStatusUpdate(status: String, inReplyToStatusID: String? = nil, lat: Double? = nil, long: Double? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, media_ids: [String]? = nil, success: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postStatusUpdate(status: String, inReplyToStatusID: String? = nil, lat: Double? = nil, long: Double? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, media_ids: [String] = [], success: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path: String = "statuses/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["status"] = status
-
-        if inReplyToStatusID != nil {
-            parameters["in_reply_to_status_id"] = inReplyToStatusID!
-        }
+        parameters["in_reply_to_status_id"] ??= inReplyToStatusID
+        parameters["trim_user"] ??= trimUser
+        
         if placeID != nil {
             parameters["place_id"] = placeID!
             parameters["display_coordinates"] = true
-        }
-        else if lat != nil && long != nil {
+        } else if lat != nil && long != nil {
             parameters["lat"] = lat!
             parameters["long"] = long!
             parameters["display_coordinates"] = true
         }
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
-        }
-        if media_ids != nil && media_ids?.count > 0 {
-            parameters["media_ids"] = media_ids!.joinWithSeparator(",")
+        
+        if !media_ids.isEmpty {
+            parameters["media_ids"] = media_ids.joinWithSeparator(",")
         }
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
@@ -167,21 +149,16 @@ public extension Swifter {
         parameters["status"] = status
         parameters["media[]"] = media
         parameters[Swifter.DataParameters.dataKey] = "media[]"
-
-        if inReplyToStatusID != nil {
-            parameters["in_reply_to_status_id"] = inReplyToStatusID!
-        }
+        parameters["in_reply_to_status_id"] ??= inReplyToStatusID
+        parameters["trim_user"] ??= trimUser
+        
         if placeID != nil {
             parameters["place_id"] = placeID!
             parameters["display_coordinates"] = true
-        }
-        else if lat != nil && long != nil {
+        } else if lat != nil && long != nil {
             parameters["lat"] = lat!
             parameters["long"] = long!
             parameters["display_coordinates"] = true
-        }
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
         }
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
@@ -225,9 +202,7 @@ public extension Swifter {
         let path = "statuses/retweet/\(id).json"
 
         var parameters = Dictionary<String, Any>()
-        if trimUser != nil {
-            parameters["trim_user"] = trimUser!
-        }
+        parameters["trim_user"] ??= trimUser
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -246,28 +221,13 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if maxWidth != nil {
-            parameters["max_width"] = maxWidth!
-        }
-        if hideMedia != nil {
-            parameters["hide_media"] = hideMedia!
-        }
-        if hideThread != nil {
-            parameters["hide_thread"] = hideThread!
-        }
-        if omitScript != nil {
-            parameters["omit_scipt"] = omitScript!
-        }
-        if align != nil {
-            parameters["align"] = align!
-        }
-        if related != nil {
-            parameters["related"] = related!
-        }
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
+        parameters["max_width"] ??= maxWidth
+        parameters["hide_media"] ??= hideMedia
+        parameters["hide_thread"] ??= hideThread
+        parameters["omit_scipt"] ??= omitScript
+        parameters["align"] ??= align
+        parameters["related"] ??= related
+        parameters["lang"] ??= lang
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -279,28 +239,13 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["url"] = url.absoluteString
-
-        if maxWidth != nil {
-            parameters["max_width"] = maxWidth!
-        }
-        if hideMedia != nil {
-            parameters["hide_media"] = hideMedia!
-        }
-        if hideThread != nil {
-            parameters["hide_thread"] = hideThread!
-        }
-        if omitScript != nil {
-            parameters["omit_scipt"] = omitScript!
-        }
-        if align != nil {
-            parameters["align"] = align!
-        }
-        if related != nil {
-            parameters["related"] = related!
-        }
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
+        parameters["max_width"] ??= maxWidth
+        parameters["hide_media"] ??= hideMedia
+        parameters["hide_thread"] ??= hideThread
+        parameters["omit_scipt"] ??= omitScript
+        parameters["align"] ??= align
+        parameters["related"] ??= related
+        parameters["lang"] ??= lang
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(status: json.object)
@@ -319,13 +264,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
+        parameters["cursor"] ??= cursor
+        parameters["stringify_ids"] ??= stringifyIDs
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -342,13 +282,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = tweetIDs.joinWithSeparator(",")
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if map != nil {
-            parameters["map"] = map!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["map"] ??= map
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -49,12 +49,8 @@ public extension Swifter {
         let path = "account/verify_credentials.json"
 
         var parameters = Dictionary<String, Any>()
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(myInfo: json.object)
@@ -72,24 +68,12 @@ public extension Swifter {
         let path = "account/settings.json"
 
         var parameters = Dictionary<String, Any>()
-        if trendLocationWOEID != nil {
-            parameters["trend_location_woeid"] = trendLocationWOEID!
-        }
-        if sleepTimeEnabled != nil {
-            parameters["sleep_time_enabled"] = sleepTimeEnabled!
-        }
-        if startSleepTime != nil {
-            parameters["start_sleep_time"] = startSleepTime!
-        }
-        if endSleepTime != nil {
-            parameters["end_sleep_time"] = endSleepTime!
-        }
-        if timeZone != nil {
-            parameters["time_zone"] = timeZone!
-        }
-        if lang != nil {
-            parameters["lang"] = lang!
-        }
+        parameters["trend_location_woeid"] ??= trendLocationWOEID
+        parameters["sleep_time_enabled"] ??= sleepTimeEnabled
+        parameters["start_sleep_time"] ??= startSleepTime
+        parameters["end_sleep_time"] ??= endSleepTime
+        parameters["time_zone"] ??= timeZone
+        parameters["lang"] ??= lang
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(settings: json.object)
@@ -105,15 +89,8 @@ public extension Swifter {
         let path = "account/update_delivery_device.json"
 
         var parameters = Dictionary<String, Any>()
-        if device {
-            parameters["device"] = "sms"
-        }
-        else {
-            parameters["device"] = "none"
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["device"] = device ? "sms" : "none"
+        parameters["include_entities"] ??= includeEntities
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(deliveryDeviceSettings: json.object)
@@ -131,24 +108,12 @@ public extension Swifter {
         let path = "account/update_profile.json"
 
         var parameters = Dictionary<String, Any>()
-        if name != nil {
-            parameters["name"] = name!
-        }
-        if url != nil {
-            parameters["url"] = url!
-        }
-        if location != nil {
-            parameters["location"] = location!
-        }
-        if description != nil {
-            parameters["description"] = description!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["name"] ??= name
+        parameters["url"] ??= url
+        parameters["location"] ??= location
+        parameters["description"] ??= description
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
         
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(profile: json.object)
@@ -160,24 +125,16 @@ public extension Swifter {
 
     Updates the authenticating user's profile background image. This method can also be used to enable or disable the profile background image. Although each parameter is marked as optional, at least one of image, tile or use must be provided when making this request.
     */
-    public func postAccountUpdateProfileBackgroundImage(imageData: NSData? = nil, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: ((profile: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        assert(imageData != nil || title != nil || use != nil, "At least one of image, tile or use must be provided when making this request")
+    public func postAccountUpdateProfileBackgroundImage(imageData: NSData, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: ((profile: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+        assert(title != nil || use != nil, "At least one of image, tile or use must be provided when making this request")
 
         let path = "account/update_profile_background_image.json"
 
         var parameters = Dictionary<String, Any>()
-        if imageData != nil {
-            parameters["image"] = imageData!.base64EncodedStringWithOptions([])
-        }
-        if title != nil {
-            parameters["title"] = title!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if use != nil {
-            parameters["use"] = use!
-        }
+        parameters["image"] = imageData.base64EncodedStringWithOptions([])
+        parameters["title"] ??= title
+        parameters["include_entities"] ??= includeEntities
+        parameters["use"] ??= use
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(profile: json.object)
@@ -193,28 +150,13 @@ public extension Swifter {
         let path = "account/update_profile_colors.json"
 
         var parameters = Dictionary<String, Any>()
-
-        if profileBackgroundColor != nil {
-            parameters["profile_background_color"] = profileBackgroundColor!
-        }
-        if profileLinkColor != nil {
-            parameters["profile_link_color"] = profileLinkColor!
-        }
-        if profileSidebarBorderColor != nil {
-            parameters["profile_sidebar_link_color"] = profileSidebarBorderColor!
-        }
-        if profileSidebarFillColor != nil {
-            parameters["profile_sidebar_fill_color"] = profileSidebarFillColor!
-        }
-        if profileTextColor != nil {
-            parameters["profile_text_color"] = profileTextColor!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["profile_background_color"] ??= profileBackgroundColor
+        parameters["profile_link_color"] ??= profileLinkColor
+        parameters["profile_sidebar_link_color"] ??= profileSidebarBorderColor
+        parameters["profile_sidebar_fill_color"] ??= profileSidebarFillColor
+        parameters["profile_text_color"] ??= profileTextColor
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(profile: json.object)
@@ -228,19 +170,13 @@ public extension Swifter {
 
     This method asynchronously processes the uploaded file before updating the user's profile image URL. You can either update your local cache the next time you request the user's information, or, at least 5 seconds after uploading the image, ask for the updated URL using GET users/show.
     */
-    public func postAccountUpdateProfileImage(imageData: NSData? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((profile: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountUpdateProfileImage(imageData: NSData, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((profile: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/update_profile_image.json"
 
         var parameters = Dictionary<String, Any>()
-        if imageData != nil {
-            parameters["image"] = imageData!.base64EncodedStringWithOptions([])
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["image"] = imageData.base64EncodedStringWithOptions([])
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(profile: json.object)
@@ -256,15 +192,9 @@ public extension Swifter {
         let path = "blocks/list.json"
 
         var parameters = Dictionary<String, Any>()
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
+        parameters["cursor"] ??= cursor
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -280,12 +210,8 @@ public extension Swifter {
         let path = "blocks/ids.json"
 
         var parameters = Dictionary<String, Any>()
-        if stringifyIDs != nil {
-            parameters["stringify_ids"] = stringifyIDs!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["stringify_ids"] ??= stringifyIDs
+        parameters["cursor"] ??= cursor
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -302,13 +228,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -320,13 +241,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -343,13 +259,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -361,13 +272,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -396,10 +302,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenNames.joinWithSeparator(",")
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -413,10 +316,7 @@ public extension Swifter {
 
         let userIDStrings = userIDs.map { String($0) }
         parameters["user_id"] = userIDStrings.joinWithSeparator(",")
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -435,10 +335,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -450,10 +347,7 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["user_id"] = userID
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -472,16 +366,9 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["q"] = q
-
-        if page != nil {
-            parameters["page"] = page!
-        }
-        if count != nil {
-            parameters["count"] = count!
-        }
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
+        parameters["page"] ??= page
+        parameters["count"] ??= count
+        parameters["include_entities"] ??= includeEntities
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -498,13 +385,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -516,13 +398,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -539,13 +416,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -557,13 +429,8 @@ public extension Swifter {
 
         var parameters = Dictionary<String, Any>()
         parameters["screen_name"] = screenName
-
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -597,25 +464,16 @@ public extension Swifter {
     400	Either an image was not provided or the image data could not be processed
     422	The image could not be resized or is too large.
     */
-    public func postAccountUpdateProfileBannerWithImageData(imageData: NSData? = nil, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountUpdateProfileBannerWithImageData(imageData: NSData, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/update_profile_banner.json"
 
         var parameters = Dictionary<String, Any>()
-        if imageData != nil {
-            parameters["banner"] = imageData!.base64EncodedStringWithOptions([])
-        }
-        if width != nil {
-            parameters["width"] = width!
-        }
-        if height != nil {
-            parameters["height"] = height!
-        }
-        if offsetLeft != nil {
-            parameters["offset_left"] = offsetLeft!
-        }
-        if offsetTop != nil {
-            parameters["offset_top"] = offsetTop!
-        }
+        parameters["banner"] = imageData.base64EncodedStringWithOptions([])
+        parameters["width"] ??= width
+        parameters["height"] ??= height
+        parameters["offset_left"] ??= offsetLeft
+        parameters["offset_top"] ??= offsetTop
+
 
         self.postJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -706,9 +564,7 @@ public extension Swifter {
         let path = "mutes/users/ids.json"
 
         var parameters = Dictionary<String, Any>()
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["cursor"] ??= cursor
 
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
@@ -724,15 +580,9 @@ public extension Swifter {
         let path = "mutes/users/list.json"
         
         var parameters = Dictionary<String, Any>()
-        if includeEntities != nil {
-            parameters["include_entities"] = includeEntities!
-        }
-        if skipStatus != nil {
-            parameters["skip_status"] = skipStatus!
-        }
-        if cursor != nil {
-            parameters["cursor"] = cursor!
-        }
+        parameters["include_entities"] ??= includeEntities
+        parameters["skip_status"] ??= skipStatus
+        parameters["cursor"] ??= cursor
         
         self.getJSONWithPath(path, baseURL: self.apiURL, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)

--- a/SwifterDemoiOS/AuthViewController.swift
+++ b/SwifterDemoiOS/AuthViewController.swift
@@ -84,12 +84,10 @@ class AuthViewController: UIViewController, SFSafariViewControllerDelegate {
                 
             // Successfully fetched timeline, so lets create and push the table view
             let tweetsViewController = self.storyboard!.instantiateViewControllerWithIdentifier("TweetsViewController") as! TweetsViewController
-                
-            if statuses != nil {
-                tweetsViewController.tweets = statuses!
+            guard let tweets = statuses else { return }
+                tweetsViewController.tweets = tweets
                 self.navigationController?.pushViewController(tweetsViewController, animated: true)
 //                self.presentViewController(tweetsViewController, animated: true, completion: nil)
-            }
 
             }, failure: failureHandler)
         


### PR DESCRIPTION
When setting the parameters, we currently use...
```
if variable != nil {
  parameters[key] = variable!
}
``` 
...which becomes rather redundant and repetitive after a while; so instead, I added a `??=` operator which checks if the `rhs` is not a nil, if so, it'll set the value of `rhs` to `lhs` (aka parameter[key])
