### PR TITLE
Fix Mac Demo failing due to UIViewController parameter

### DIFF
--- a/Swifter/SwifterAuth.swift
+++ b/Swifter/SwifterAuth.swift
@@ -33,78 +33,91 @@ import Foundation
 #endif
 
 public extension Swifter {
-
-    public typealias TokenSuccessHandler = (accessToken: SwifterCredential.OAuthAccessToken?, response: NSURLResponse) -> Void
-
-    /**
-        Begin Authorization with a Callback URL.
-        - Parameter presentFromViewController: The viewController used to present the SFSafariViewController.
-            The UIViewController must inherit SFSafariViewControllerDelegate
-    */
     
-    public func authorizeWithCallbackURL(callbackURL: NSURL, presentFromViewController presentingViewController: UIViewController? = nil, success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
-        self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: {
-            token, response in
-
+    public typealias TokenSuccessHandler = (accessToken: SwifterCredential.OAuthAccessToken?, response: NSURLResponse) -> Void
+    
+    /**
+     Begin Authorization with a Callback URL.
+     - OS X only
+     */
+    #if os(OSX)
+    public func authorizeWithCallbackURL(callbackURL: NSURL, success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
+        self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: { token, response in
             var requestToken = token!
-
-            NSNotificationCenter.defaultCenter().addObserverForName(CallbackNotification.notificationName, object: nil, queue: NSOperationQueue.mainQueue(), usingBlock:{
-                notification in
-
+            
+            NSNotificationCenter.defaultCenter().addObserverForName(CallbackNotification.notificationName, object: nil, queue: NSOperationQueue.mainQueue()) { notification in
                 NSNotificationCenter.defaultCenter().removeObserver(self)
-                presentingViewController?.presentedViewController?.dismissViewControllerAnimated(true, completion: nil)
                 let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
-
                 let parameters = url.query!.parametersFromQueryString()
                 requestToken.verifier = parameters["oauth_verifier"]
-
-                self.postOAuthAccessTokenWithRequestToken(requestToken, success: {
-                    accessToken, response in
-
+                
+                self.postOAuthAccessTokenWithRequestToken(requestToken, success: { accessToken, response in
                     self.client.credential = SwifterCredential(accessToken: accessToken!)
                     success?(accessToken: accessToken!, response: response)
-
                     }, failure: failure)
-                })
-
+            }
+            
             let authorizeURL = NSURL(string: "/oauth/authorize", relativeToURL: self.apiURL)
             let queryURL = NSURL(string: authorizeURL!.absoluteString + "?oauth_token=\(token!.key)")!
-            
-            #if os(iOS)
-                if #available (iOS 9.0, *) {
-                    if let viewControllerDelegate = presentingViewController as? SFSafariViewControllerDelegate {
-                        let webView = SFSafariViewController(URL: queryURL)
-                        webView.delegate = viewControllerDelegate
-                        presentingViewController?.presentViewController(webView, animated: true, completion: nil)
-                    } else {
-                        UIApplication.sharedApplication().openURL(queryURL)
-                    }
-                } else {
-                    UIApplication.sharedApplication().openURL(queryURL)
-                }
-            #else
-                NSWorkspace.sharedWorkspace().openURL(queryURL)
-            #endif
-            
+            NSWorkspace.sharedWorkspace().openURL(queryURL)
             }, failure: failure)
     }
-
+    #endif
+    
+    /**
+     Begin Authorization with a Callback URL
+     
+     - Parameter presentFromViewController: The viewController used to present the SFSafariViewController.
+     The UIViewController must inherit SFSafariViewControllerDelegate
+     
+     */
+    
+    #if os(iOS)
+    public func authorizeWithCallbackURL<T: UIViewController where T: SFSafariViewControllerDelegate>(callbackURL: NSURL, presentFromViewController presentingViewController: T, success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
+    self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: { token, response in
+    var requestToken = token!
+    
+    NSNotificationCenter.defaultCenter().addObserverForName(CallbackNotification.notificationName, object: nil, queue: NSOperationQueue.mainQueue()) { notification in
+    NSNotificationCenter.defaultCenter().removeObserver(self)
+    presentingViewController.presentedViewController?.dismissViewControllerAnimated(true, completion: nil)
+    let url = notification.userInfo![CallbackNotification.optionsURLKey] as! NSURL
+    
+    let parameters = url.query!.parametersFromQueryString()
+    requestToken.verifier = parameters["oauth_verifier"]
+    
+    self.postOAuthAccessTokenWithRequestToken(requestToken, success: { accessToken, response in
+    self.client.credential = SwifterCredential(accessToken: accessToken!)
+    success?(accessToken: accessToken!, response: response)
+    }, failure: failure)
+    }
+    
+    let authorizeURL = NSURL(string: "/oauth/authorize", relativeToURL: self.apiURL)
+    let queryURL = NSURL(string: authorizeURL!.absoluteString + "?oauth_token=\(token!.key)")!
+    
+    let safariView = SFSafariViewController(URL: queryURL)
+    safariView.delegate = presentingViewController
+    presentingViewController.presentViewController(webView, animated: true, completion: nil)
+    
+    }, failure: failure)
+    }
+    #endif
+    
     public class func handleOpenURL(url: NSURL) {
         let notification = NSNotification(name: CallbackNotification.notificationName, object: nil,
-            userInfo: [CallbackNotification.optionsURLKey: url])
+                                                                                       userInfo: [CallbackNotification.optionsURLKey: url])
         NSNotificationCenter.defaultCenter().postNotification(notification)
     }
-
+    
     public func authorizeAppOnlyWithSuccess(success: TokenSuccessHandler?, failure: FailureHandler?) {
         self.postOAuth2BearerTokenWithSuccess({ json, response in
             if let tokenType = json["token_type"].string {
                 if tokenType == "bearer" {
                     let accessToken = json["access_token"].string
-
+                    
                     let credentialToken = SwifterCredential.OAuthAccessToken(key: accessToken!, secret: "")
-
+                    
                     self.client.credential = SwifterCredential(accessToken: credentialToken)
-
+                    
                     success?(accessToken: credentialToken, response: response)
                 } else {
                     let error = NSError(domain: "Swifter", code: SwifterError.appOnlyAuthenticationErrorCode, userInfo: [NSLocalizedDescriptionKey: "Cannot find bearer token in server response"]);
@@ -117,69 +130,69 @@ public extension Swifter {
                 let error = NSError(domain: SwifterError.domain, code: SwifterError.appOnlyAuthenticationErrorCode, userInfo: [NSLocalizedDescriptionKey: "Cannot find JSON dictionary in response"]);
                 failure?(error: error)
             }
-
-        }, failure: failure)
+            
+            }, failure: failure)
     }
-
+    
     public func postOAuth2BearerTokenWithSuccess(success: JSONSuccessHandler?, failure: FailureHandler?) {
         let path = "/oauth2/token"
-
+        
         var parameters = Dictionary<String, Any>()
         parameters["grant_type"] = "client_credentials"
-
+        
         self.jsonRequestWithPath(path, baseURL: self.apiURL, method: .POST, parameters: parameters, success: success, failure: failure)
     }
-
+    
     public func postOAuth2InvalidateBearerTokenWithSuccess(success: TokenSuccessHandler?, failure: FailureHandler?) {
         let path = "/oauth2/invalidate_token"
-
+        
         self.jsonRequestWithPath(path, baseURL: self.apiURL, method: .POST, parameters: [:], success: { json, response in
             if let accessToken = json["access_token"].string {
                 self.client.credential = nil
-
+                
                 let credentialToken = SwifterCredential.OAuthAccessToken(key: accessToken, secret: "")
-
+                
                 success?(accessToken: credentialToken, response: response)
             }
             else {
                 success?(accessToken: nil, response: response)
             }
-
+            
             }, failure: failure)
     }
-
+    
     public func postOAuthRequestTokenWithCallbackURL(callbackURL: NSURL, success: TokenSuccessHandler, failure: FailureHandler?) {
         let path = "/oauth/request_token"
-
+        
         var parameters =  Dictionary<String, Any>()
-
+        
         parameters["oauth_callback"] = callbackURL.absoluteString
-
+        
         self.client.post(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
             data, response in
-
+            
             let responseString = NSString(data: data, encoding: NSUTF8StringEncoding)
             let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString as String!)
             success(accessToken: accessToken, response: response)
-
+            
             }, failure: failure)
     }
-
+    
     public func postOAuthAccessTokenWithRequestToken(requestToken: SwifterCredential.OAuthAccessToken, success: TokenSuccessHandler, failure: FailureHandler?) {
         if let verifier = requestToken.verifier {
             let path =  "/oauth/access_token"
-
+            
             var parameters = Dictionary<String, Any>()
             parameters["oauth_token"] = requestToken.key
             parameters["oauth_verifier"] = verifier
-
+            
             self.client.post(path, baseURL: self.apiURL, parameters: parameters, uploadProgress: nil, downloadProgress: nil, success: {
                 data, response in
-
+                
                 let responseString = NSString(data: data, encoding: NSUTF8StringEncoding)
                 let accessToken = SwifterCredential.OAuthAccessToken(queryString: responseString! as String)
                 success(accessToken: accessToken, response: response)
-
+                
                 }, failure: failure)
         }
         else {
@@ -188,5 +201,5 @@ public extension Swifter {
             failure?(error: error)
         }
     }
-
+    
 }

--- a/SwifterDemoMac/Base.lproj/Main.storyboard
+++ b/SwifterDemoMac/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8164.2" systemVersion="15A226f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10102" systemVersion="15E39c" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8164.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10102"/>
     </dependencies>
     <scenes>
         <!--Window Controller-->
@@ -16,7 +16,6 @@
                         <view key="contentView" id="O92-4t-NeX">
                             <rect key="frame" x="14" y="22" width="480" height="270"/>
                             <autoresizingMask key="autoresizingMask"/>
-                            <animations/>
                         </view>
                     </window>
                     <connections>
@@ -34,7 +33,6 @@
                     <view key="view" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Fixed #125 by creating 2 separate methods for authorizeWithCallbackURL: 
One with `#if os(OSX)` and another with `#if os(iOS)`