### PR TITLE
Added CocoaPods Support

### DIFF
--- a/External/CommonCrypto/injectXcodePath.sh
+++ b/External/CommonCrypto/injectXcodePath.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Rewrites the Xcode paths for the modulemaps that reference CommonCrypto
+defaultXcodePath="/Applications/Xcode.app/Contents/Developer"
+realXcodePath="`xcode-select -p`"
+
+fatal() {
+    echo "[fatal] $1" 1>&2
+    exit 1
+}
+
+absPath() {
+    case "$1" in
+        /*)
+            printf "%s\n" "$1"
+            ;;
+        *)
+            printf "%s\n" "$PWD/$1"
+            ;;
+    esac;
+}
+
+scriptDir="`dirname $0`"
+scriptName="`basename $0`"
+absScriptDir="`cd $scriptDir; pwd`"
+
+main() {
+    for f in `find ${absScriptDir} -name module.modulemap`; do
+        cat ${f} | sed "s,${defaultXcodePath},${realXcodePath},g" > ${f}.new || fatal "Failed to update modulemap ${f}"
+        mv ${f}.new ${f} || fatal "Failed to replace modulemap ${f}"
+    done
+}
+
+main $*

--- a/External/CommonCrypto/iphoneos/module.modulemap
+++ b/External/CommonCrypto/iphoneos/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCrypto [system] {
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    export *
+}

--- a/External/CommonCrypto/iphonesimulator/module.modulemap
+++ b/External/CommonCrypto/iphonesimulator/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCrypto [system] {
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    export *
+}

--- a/External/CommonCrypto/macosx/module.modulemap
+++ b/External/CommonCrypto/macosx/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCrypto [system] {
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    export *
+}

--- a/Swifter.h
+++ b/Swifter.h
@@ -1,5 +1,5 @@
 //
-//  Swifter-Bridging-Header.h
+//  Swifter.h
 //  Swifter
 //
 //  Copyright (c) 2014 Matt Donnelly.
@@ -23,4 +23,8 @@
 //  THE SOFTWARE.
 //
 
-#import <CommonCrypto/CommonCrypto.h>
+#import <UIKit/UIKit.h>
+
+FOUNDATION_EXPORT double SwifterVersionNumber;
+
+FOUNDATION_EXPORT const unsigned char SwifterVersionString[];

--- a/Swifter.podspec.json
+++ b/Swifter.podspec.json
@@ -1,0 +1,27 @@
+{
+    "name": "Swifter",
+    "version": "1.6",
+    "summary": "🐦 A Twitter framework for iOS & OS X written in Swift",
+    "description": "🐦 A Twitter framework for iOS & OS X written in Swift",
+    "homepage": "https://github.com/mattdonnelly/Swifter",
+    "license": "MIT",
+    "source": {
+        "git": "https://github.com/cjwirth/Swifter.git",
+        "branch": "master" 
+    },
+    "authors": ["Matt Donnelly"],
+    "platforms": {
+        "osx": "10.10",
+        "ios": "8.0"
+    },
+    "source_files": "Swifter/*.{h,swift}",
+    "requires_arc": true,
+    "preserve_paths":  "External/CommonCrypto/**/*",
+    "prepare_command": "External/CommonCrypto/injectXcodePath.sh",
+    "xcconfig": {
+        "SWIFT_INCLUDE_PATHS[sdk=iphoneos*]": "$(SRCROOT)/Swifter/External/CommonCrypto/iphoneos",
+        "SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]": "$(SRCROOT)/Swifter/External/CommonCrypto/iphonesimulator",
+        "SWIFT_INCLUDE_PATHS[sdk=macosx*]": "$(SRCROOT)/Swifter/External/CommonCrypto/macosx"
+    }
+}
+

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -40,8 +40,6 @@
 		8B9F514E1944A8DC00894629 /* Dictionary+Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F51471944A8DC00894629 /* Dictionary+Swifter.swift */; };
 		8B9F51531944A8DC00894629 /* String+Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F514A1944A8DC00894629 /* String+Swifter.swift */; };
 		8B9F51541944A8DC00894629 /* String+Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F514A1944A8DC00894629 /* String+Swifter.swift */; };
-		8B9F51551944A8DC00894629 /* Swifter-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9F514B1944A8DC00894629 /* Swifter-Bridging-Header.h */; };
-		8B9F51561944A8DC00894629 /* Swifter-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9F514B1944A8DC00894629 /* Swifter-Bridging-Header.h */; };
 		8B9F51571944A8DC00894629 /* Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F514C1944A8DC00894629 /* Swifter.swift */; };
 		8B9F51581944A8DC00894629 /* Swifter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F514C1944A8DC00894629 /* Swifter.swift */; };
 		8BA50EC71953828A00FB1829 /* SwifterAppOnlyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA50EC61953828A00FB1829 /* SwifterAppOnlyClient.swift */; };
@@ -164,7 +162,6 @@
 		8B9F51131944A61D00894629 /* SwifterMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwifterMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B9F51471944A8DC00894629 /* Dictionary+Swifter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Swifter.swift"; sourceTree = "<group>"; };
 		8B9F514A1944A8DC00894629 /* String+Swifter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Swifter.swift"; sourceTree = "<group>"; };
-		8B9F514B1944A8DC00894629 /* Swifter-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Swifter-Bridging-Header.h"; sourceTree = "<group>"; };
 		8B9F514C1944A8DC00894629 /* Swifter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swifter.swift; sourceTree = "<group>"; };
 		8BA50EC61953828A00FB1829 /* SwifterAppOnlyClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAppOnlyClient.swift; sourceTree = "<group>"; };
 		8BC32D3C1955EEE100FF75A0 /* SwifterTrends.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTrends.swift; sourceTree = "<group>"; };
@@ -189,6 +186,11 @@
 		F6B4D5771C7BAC4500E06514 /* SwifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwifterTests.swift; sourceTree = "<group>"; };
 		F6B4D5791C7BAC4500E06514 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F6B4D5801C7BAC5E00E06514 /* String+SwifterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SwifterTests.swift"; sourceTree = "<group>"; };
+		FBA2CDD11C7B0B46002A3857 /* Swifter.podspec.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Swifter.podspec.json; sourceTree = "<group>"; };
+		FBA2CDD41C7B0B67002A3857 /* injectXcodePath.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = injectXcodePath.sh; path = External/CommonCrypto/injectXcodePath.sh; sourceTree = "<group>"; };
+		FBA2CDD81C7B0B8A002A3857 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = External/CommonCrypto/iphoneos/module.modulemap; sourceTree = "<group>"; };
+		FBA2CDD91C7B0B8F002A3857 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = External/CommonCrypto/iphonesimulator/module.modulemap; sourceTree = "<group>"; };
+		FBA2CDDA1C7B0B94002A3857 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = External/CommonCrypto/macosx/module.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,6 +289,7 @@
 		8B9F50E41944A5AB00894629 = {
 			isa = PBXGroup;
 			children = (
+				FBA2CDD01C7B0B1C002A3857 /* Metadata */,
 				8B9F51461944A8DC00894629 /* Swifter */,
 				8B300C201944AA1A00993175 /* SwifterDemoiOS */,
 				8B300C481944AECB00993175 /* SwifterDemoMac */,
@@ -311,7 +314,6 @@
 			isa = PBXGroup;
 			children = (
 				8B5EFF14195F09F600B354F9 /* Swifter.h */,
-				8B9F514B1944A8DC00894629 /* Swifter-Bridging-Header.h */,
 				8B9F514C1944A8DC00894629 /* Swifter.swift */,
 				8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */,
 				8B548F581945325E00EE2927 /* SwifterAuth.swift */,
@@ -363,6 +365,50 @@
 			path = SwifterTests;
 			sourceTree = "<group>";
 		};
+		FBA2CDD01C7B0B1C002A3857 /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				FBA2CDD31C7B0B49002A3857 /* CommonCrypto */,
+				FBA2CDD11C7B0B46002A3857 /* Swifter.podspec.json */,
+			);
+			name = Metadata;
+			sourceTree = "<group>";
+		};
+		FBA2CDD31C7B0B49002A3857 /* CommonCrypto */ = {
+			isa = PBXGroup;
+			children = (
+				FBA2CDD51C7B0B75002A3857 /* iphoneos */,
+				FBA2CDD61C7B0B7B002A3857 /* iphonesimulator */,
+				FBA2CDD71C7B0B80002A3857 /* macosx */,
+				FBA2CDD41C7B0B67002A3857 /* injectXcodePath.sh */,
+			);
+			name = CommonCrypto;
+			sourceTree = "<group>";
+		};
+		FBA2CDD51C7B0B75002A3857 /* iphoneos */ = {
+			isa = PBXGroup;
+			children = (
+				FBA2CDD81C7B0B8A002A3857 /* module.modulemap */,
+			);
+			name = iphoneos;
+			sourceTree = "<group>";
+		};
+		FBA2CDD61C7B0B7B002A3857 /* iphonesimulator */ = {
+			isa = PBXGroup;
+			children = (
+				FBA2CDD91C7B0B8F002A3857 /* module.modulemap */,
+			);
+			name = iphonesimulator;
+			sourceTree = "<group>";
+		};
+		FBA2CDD71C7B0B80002A3857 /* macosx */ = {
+			isa = PBXGroup;
+			children = (
+				FBA2CDDA1C7B0B94002A3857 /* module.modulemap */,
+			);
+			name = macosx;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -370,7 +416,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B9F51551944A8DC00894629 /* Swifter-Bridging-Header.h in Headers */,
 				8B5EFF15195F09F600B354F9 /* Swifter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -379,7 +424,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B9F51561944A8DC00894629 /* Swifter-Bridging-Header.h in Headers */,
 				8B5EFF16195F09F600B354F9 /* Swifter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -873,7 +917,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(inherited) $(SRCROOT)/External/CommonCrypto/iphoneos";
+				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(SRCROOT)/External/CommonCrypto/iphonesimulator";
 			};
 			name = Debug;
 		};
@@ -890,7 +935,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mattdonnelly.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(inherited) $(SRCROOT)/External/CommonCrypto/iphoneos";
+				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(SRCROOT)/External/CommonCrypto/iphonesimulator";
 			};
 			name = Release;
 		};
@@ -916,7 +962,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/External/CommonCrypto/macosx";
 			};
 			name = Debug;
 		};
@@ -939,7 +985,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Swifter/Swifter-Bridging-Header.h";
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/External/CommonCrypto/macosx";
 			};
 			name = Release;
 		};

--- a/Swifter/String+Swifter.swift
+++ b/Swifter/String+Swifter.swift
@@ -24,6 +24,7 @@
 //
 
 import Foundation
+import CommonCrypto
 
 extension String {
 


### PR DESCRIPTION
So I wanted to install this library through CocoaPods, along with all of my other libraries, so I decided to go and make the changes myself and submit a pull request. 

This is kind of a confusing pull request (had to figure out how to use CommonCrypto without Xcode getting all kinds of mad :persevere: )

So I suppose a little bit of explanation is in order.
I read a whole lot of things online, but the one that actually ended up helping the most was [this article](https://ind.ie/labs/blog/using-system-headers-in-swift/).
### Module Maps

CocoaPods builds your library as a Framework. Frameworks end up being Modules. Modules aren't allowed import non-modular things into their code. That's why there's a ton of hurt trying to link to CommonCrypto.

I solved this by making individual Module Maps for CommonCrypto for each platform. This makes it so I can kind of "privately" import CommonCrypto without exposing it to the outside, which I think is what makes the compiler so angry.

I added it to the project targets themselves, so the default project still builds like normal. I also added it to the Podspec, so when people import the project, it will still be able to use the right module map.

`injectXcodePath.sh` is a neat little script from the blog post up above. It looks into the module maps, where it is importing the CommonCrypto header, and changes it to be in the correct location for the user's machine. 
### Needs Changing

The podspec points to my fork. The reason for this, is that the last release tag is from a long time ago, and wouldn't build on my machine. So I made the branch `master`, and pointed it towards my fork so it has the module maps. Otherwise it wouldn't build.

After merging (or just before), we'll have to change it back to `mattdonnelly/Swifter` for consistency, and then we can push it to the main Pods repo.
