### PR TITLE
Remove [] from allowed characters of urlEncodings.

### DIFF
--- a/Swifter/Dictionary+Swifter.swift
+++ b/Swifter/Dictionary+Swifter.swift
@@ -53,7 +53,7 @@ extension Dictionary {
 
         for (key, value) in self {
             let keyString: String = "\(key)".urlEncodedStringWithEncoding()
-            let valueString: String = "\(value)".urlEncodedStringWithEncoding()
+            let valueString: String = "\(value)".urlEncodedStringWithEncoding(keyString == "status")
             let query: String = "\(keyString)=\(valueString)"
             parts.append(query)
         }

--- a/Swifter/String+Swifter.swift
+++ b/Swifter/String+Swifter.swift
@@ -42,10 +42,12 @@ extension String {
         }
     }
     
-    func urlEncodedStringWithEncoding() -> String {
+    func urlEncodedStringWithEncoding(all: Bool = false) -> String {
         let allowedCharacterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
         allowedCharacterSet.removeCharactersInString("\n:#/?@!$&'()*+,;=")
-        allowedCharacterSet.addCharactersInString("[]")
+        if !all {
+            allowedCharacterSet.addCharactersInString("[]")
+        }
         return self.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
 
     }

--- a/Swifter/String+Swifter.swift
+++ b/Swifter/String+Swifter.swift
@@ -45,6 +45,7 @@ extension String {
     func urlEncodedStringWithEncoding() -> String {
         let allowedCharacterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
         allowedCharacterSet.removeCharactersInString("\n:#/?@!$&'()*+,;=")
+        allowedCharacterSet.addCharactersInString("[]")
         return self.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
 
     }

--- a/Swifter/String+Swifter.swift
+++ b/Swifter/String+Swifter.swift
@@ -45,7 +45,6 @@ extension String {
     func urlEncodedStringWithEncoding() -> String {
         let allowedCharacterSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
         allowedCharacterSet.removeCharactersInString("\n:#/?@!$&'()*+,;=")
-        allowedCharacterSet.addCharactersInString("[]")
         return self.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacterSet)!
 
     }


### PR DESCRIPTION
If "[]" are not escaped,  Dictionary<String, String> cannot be posted via Swifter instance as below.

```
let swifter = Swifter(consumerKey: TWITTER_CONSUMER_KEY, consumerSecret: TWITTER_CONSUMER_SECRET, oauthToken: TWITTER_ACCESS_TOKEN, oauthTokenSecret: TWITTER_ACCESS_TOKEN_SECRET)

let text = {"date" : NSDate().description}.description
swifter.postStatusUpdate(text, success: { status in

            }, failure: { error in
                debugPrint(error)
            })
```
then, HTTP status code 401 is returned from Twitter.