### PR TITLE
Use Tag enums for User (id/screenName) and List (id/slug) 

### DIFF
--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		8BF1D6891948C11E00E3AA64 /* SwifterCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */; };
 		A17A694F1C78336200063DFD /* Operator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator++.swift */; };
 		A17A69501C78336300063DFD /* Operator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator++.swift */; };
+		A1BDB38C1D4C864200B0080F /* SwifterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BDB38A1D4C859200B0080F /* SwifterTag.swift */; };
+		A1BDB38D1D4C864200B0080F /* SwifterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BDB38A1D4C859200B0080F /* SwifterTag.swift */; };
 		A1C7F0A51C7845FD00955ADB /* SwifterMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9F51131944A61D00894629 /* SwifterMac.framework */; };
 		A1C7F0A61C7845FD00955ADB /* SwifterMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9F51131944A61D00894629 /* SwifterMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1DD65C51B618D7E0070E6FC /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A1DD65C41B618D7E0070E6FC /* Launch Screen.storyboard */; };
@@ -191,6 +193,7 @@
 		8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAccountsClient.swift; sourceTree = "<group>"; };
 		8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterCredential.swift; sourceTree = "<group>"; };
 		A17A694D1C78333400063DFD /* Operator++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operator++.swift"; sourceTree = "<group>"; };
+		A1BDB38A1D4C859200B0080F /* SwifterTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTag.swift; sourceTree = "<group>"; };
 		A1DD65C41B618D7E0070E6FC /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = "Launch Screen.storyboard"; path = "../Swifter/Launch Screen.storyboard"; sourceTree = "<group>"; };
 		A1E207A61D4B85D90093E498 /* HMAC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
 		A1E207A71D4B85D90093E498 /* SHA1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SHA1.swift; sourceTree = "<group>"; };
@@ -324,6 +327,7 @@
 			children = (
 				8B5EFF14195F09F600B354F9 /* Swifter.h */,
 				8B9F514C1944A8DC00894629 /* Swifter.swift */,
+				A1BDB38A1D4C859200B0080F /* SwifterTag.swift */,
 				8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */,
 				8B548F581945325E00EE2927 /* SwifterAuth.swift */,
 				8B548F5B1945331D00EE2927 /* SwifterTimelines.swift */,
@@ -624,6 +628,7 @@
 				A17A694F1C78336200063DFD /* Operator++.swift in Sources */,
 				8BCF43291947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43261947CABA00E63301 /* SwifterSuggested.swift in Sources */,
+				A1BDB38C1D4C864200B0080F /* SwifterTag.swift in Sources */,
 				8B116AF1194601970019A4DC /* SwifterHTTPRequest.swift in Sources */,
 				8B552D2D194695F80052EB86 /* SwifterStreaming.swift in Sources */,
 				8B548F5619450BDB00EE2927 /* SwifterOAuthClient.swift in Sources */,
@@ -664,6 +669,7 @@
 				A17A69501C78336300063DFD /* Operator++.swift in Sources */,
 				8BCF432A1947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43271947CABA00E63301 /* SwifterSuggested.swift in Sources */,
+				A1BDB38D1D4C864200B0080F /* SwifterTag.swift in Sources */,
 				8B116AF2194601970019A4DC /* SwifterHTTPRequest.swift in Sources */,
 				8B552D2E194695F80052EB86 /* SwifterStreaming.swift in Sources */,
 				8B548F5719450BDB00EE2927 /* SwifterOAuthClient.swift in Sources */,

--- a/Swifter/Swifter.swift
+++ b/Swifter/Swifter.swift
@@ -52,44 +52,6 @@ public enum TwitterURL {
     
 }
 
-public enum UserTag {
-    case id(String)
-    case screenName(String)
-    
-    var key: String {
-        switch self {
-        case .id:           return "user_id"
-        case .screenName:   return "screen_name"
-        }
-    }
-    
-    var value: String {
-        switch self {
-        case .id(let id):           return id
-        case .screenName(let user): return user
-        }
-    }
-}
-
-public enum UsersTag {
-    case id([String])
-    case screenName([String])
-    
-    var key: String {
-        switch self {
-        case .id:           return "user_id"
-        case .screenName:   return "screen_name"
-        }
-    }
-    
-    var value: String {
-        switch self {
-        case .id(let id):           return id.joined(separator: ",")
-        case .screenName(let user): return user.joined(separator: ",")
-        }
-    }
-}
-
 public class Swifter {
     
     // MARK: - Types

--- a/Swifter/Swifter.swift
+++ b/Swifter/Swifter.swift
@@ -52,6 +52,44 @@ public enum TwitterURL {
     
 }
 
+public enum UserTag {
+    case id(String)
+    case screenName(String)
+    
+    var key: String {
+        switch self {
+        case .id:           return "user_id"
+        case .screenName:   return "screen_name"
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .id(let id):           return id
+        case .screenName(let user): return user
+        }
+    }
+}
+
+public enum UsersTag {
+    case id([String])
+    case screenName([String])
+    
+    var key: String {
+        switch self {
+        case .id:           return "user_id"
+        case .screenName:   return "screen_name"
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .id(let id):           return id.joined(separator: ",")
+        case .screenName(let user): return user.joined(separator: ",")
+        }
+    }
+}
+
 public class Swifter {
     
     // MARK: - Types

--- a/Swifter/SwifterAuth.swift
+++ b/Swifter/SwifterAuth.swift
@@ -41,7 +41,7 @@ public extension Swifter {
      - OS X only
      */
     #if os(OSX)
-    public func authorizeWithCallbackURL(_ callbackURL: URL, success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
+    public func authorize(with callbackURL: URL, success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
         self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: { token, response in
             var requestToken = token!
             
@@ -73,7 +73,7 @@ public extension Swifter {
      */
     
     #if os(iOS)
-    public func authorizeWithCallbackURL(_ callbackURL: URL, presentFromViewController presentingViewController: UIViewController? , success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
+    public func authorize(with callbackURL: URL, presentFrom presentingViewController: UIViewController? , success: TokenSuccessHandler?, failure: FailureHandler? = nil) {
         self.postOAuthRequestTokenWithCallbackURL(callbackURL, success: { token, response in
             var requestToken = token!
             NotificationCenter.default.addObserver(forName: .SwifterCallbackNotification, object: nil, queue: .main) { notification in
@@ -109,7 +109,7 @@ public extension Swifter {
         NotificationCenter.default.post(notification)
     }
     
-    public func authorizeAppOnlyWithSuccess(_ success: TokenSuccessHandler?, failure: FailureHandler?) {
+    public func authorizeAppOnly(success: TokenSuccessHandler?, failure: FailureHandler?) {
         self.postOAuth2BearerTokenWithSuccess({ json, response in
             if let tokenType = json["token_type"].string {
                 if tokenType == "bearer" {
@@ -135,7 +135,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func postOAuth2BearerTokenWithSuccess(_ success: JSONSuccessHandler?, failure: FailureHandler?) {
+    public func postOAuth2BearerToken(success: JSONSuccessHandler?, failure: FailureHandler?) {
         let path = "oauth2/token"
         
         var parameters = Dictionary<String, Any>()
@@ -144,7 +144,7 @@ public extension Swifter {
         self.jsonRequest(path: path, baseURL: .oauth, method: .POST, parameters: parameters, success: success, failure: failure)
     }
     
-    public func postOAuth2InvalidateBearerTokenWithSuccess(_ success: TokenSuccessHandler?, failure: FailureHandler?) {
+    public func postOAuth2InvalidateBearerToken(success: TokenSuccessHandler?, failure: FailureHandler?) {
         let path = "oauth2/invalidate_token"
         
         self.jsonRequest(path: path, baseURL: .oauth, method: .POST, parameters: [:], success: { json, response in
@@ -162,7 +162,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func postOAuthRequestTokenWithCallbackURL(_ callbackURL: URL, success: TokenSuccessHandler, failure: FailureHandler?) {
+    public func postOAuthRequestToken(with callbackURL: URL, success: TokenSuccessHandler, failure: FailureHandler?) {
         let path = "oauth/request_token"
         
         var parameters =  Dictionary<String, Any>()
@@ -181,7 +181,7 @@ public extension Swifter {
         })
     }
     
-    public func postOAuthAccessTokenWithRequestToken(_ requestToken: Credential.OAuthAccessToken, success: TokenSuccessHandler, failure: FailureHandler?) {
+    public func postOAuthAccessToken(with requestToken: Credential.OAuthAccessToken, success: TokenSuccessHandler, failure: FailureHandler?) {
         if let verifier = requestToken.verifier {
             let path =  "oauth/access_token"
             

--- a/Swifter/SwifterFavorites.swift
+++ b/Swifter/SwifterFavorites.swift
@@ -34,7 +34,7 @@ public extension Swifter {
 
     If you do not provide either a user_id or screen_name to this method, it will assume you are requesting on behalf of the authenticating user. Specify one or the other for best results.
     */
-    public func getFavoritesListWithCount(_ count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFavoritesList(withCount count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -47,7 +47,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFavoritesListWithUserID(_ userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFavoritesList(withUserID userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -61,7 +61,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFavoritesListWithScreenName(_ screenName: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFavoritesList(withScreenName screenName: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -82,7 +82,7 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func postDestroyFavoriteWithID(_ id: String, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDestroyFavorite(with id: String, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -101,7 +101,7 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func postCreateFavoriteWithID(_ id: String, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: HTTPRequest.FailureHandler? = nil) {
+    public func postCreateFavorite(with id: String, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: HTTPRequest.FailureHandler? = nil) {
         let path = "favorites/create.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterFavorites.swift
+++ b/Swifter/SwifterFavorites.swift
@@ -46,30 +46,19 @@ public extension Swifter {
             success?(statuses: json.array)
             }, failure: failure)
     }
-
-    public func getFavoritesList(withUserID userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    
+    public func getFavoritesList(for userTag: UserTag, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
-
+        
         var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        switch userTag {
+        case .id(let id):           parameters["user_id"] = id
+        case .screenName(let user): parameters["screen_name"] = user
+        }
         parameters["count"] ??= count
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(statuses: json.array)
-            }, failure: failure)
-    }
-
-    public func getFavoritesList(withScreenName screenName: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "favorites/list.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["count"] ??= count
-        parameters["since_id"] ??= sinceID
-        parameters["max_id"] ??= maxID
-
+        
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(statuses: json.array)
             }, failure: failure)

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from. Use POST friendships/update to set the "no retweets" status for a given user account on behalf of the current user.
     */
-    public func getFriendshipsNoRetweetsIDsWithStringifyIDs(_ stringifyIDs: Bool = true, success: ((ids: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsNoRetweetsIDs(stringifyIDs: Bool = true, success: ((ids: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/no_retweets/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -53,7 +53,7 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFriendsIDsWithID(_ id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDs(withId id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -67,7 +67,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func getFriendsIDsWithScreenName(_ screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDs(withScreenName screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -90,7 +90,7 @@ public extension Swifter {
     
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFollowersIDsWithID(_ id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDs(withId id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -104,7 +104,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func getFollowersIDsWithScreenName(_ screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDs(withScreenName screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -123,7 +123,7 @@ public extension Swifter {
     
     Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
     */
-    public func getFriendshipsIncomingWithCursor(_ cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsIncoming(with cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/incoming.json"
         
         var parameters = Dictionary<String, Any>()
@@ -140,7 +140,7 @@ public extension Swifter {
     
     Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
     */
-    public func getFriendshipsOutgoingWithCursor(_ cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsOutgoing(with cursor: String? = nil, stringifyIDs: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/outgoing.json"
         
         var parameters = Dictionary<String, Any>()
@@ -161,7 +161,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postCreateFriendshipWithID(_ id: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postCreateFriendship(withId id: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -173,7 +173,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postCreateFriendshipWithScreenName(_ screenName: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postCreateFriendship(withScreenName screenName: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -194,7 +194,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postDestroyFriendshipWithID(_ id: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDestroyFriendship(withId id: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -205,7 +205,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postDestroyFriendshipWithScreenName(_ screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDestroyFriendship(withScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -221,7 +221,7 @@ public extension Swifter {
 
     Allows one to enable or disable retweets and device notifications from the specified user.
     */
-    public func postUpdateFriendshipWithID(_ id: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUpdateFriendship(withId id: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -234,7 +234,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postUpdateFriendshipWithScreenName(_ screenName: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUpdateFriendship(withScreenName screenName: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -252,7 +252,7 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func getFriendshipsShowWithSourceID(_ sourceID: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsShow(sourceID: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -265,7 +265,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFriendshipsShowWithSourceScreenName(_ sourceScreenName: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsShow(sourceScreenName: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -285,7 +285,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFriendsListWithID(_ id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsList(withId id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -300,7 +300,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFriendsListWithScreenName(_ screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsList(withScreenName screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -323,7 +323,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFollowersListWithID(_ id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersList(withId id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -338,7 +338,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getFollowersListWithScreenName(_ screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersList(withScreenName screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -358,7 +358,7 @@ public extension Swifter {
 
     Returns the relationships of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by, none.
     */
-    public func getFriendshipsLookupWithScreenNames(_ screenNames: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
+    public func getFriendshipsLookup(withScreenNames screenNames: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
         let path = "friendships/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -369,7 +369,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func getFriendshipsLookupWithIDs(_ ids: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsLookup(withIds ids: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/lookup.json"
         
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterFollowers.swift
+++ b/Swifter/SwifterFollowers.swift
@@ -53,25 +53,11 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFriendsIDs(withId id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["cursor"] ??= cursor
-        parameters["stringify_ids"] ??= stringifyIDs
-        parameters["count"] ??= count
-        
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-            }, failure: failure)
-    }
-    
-    public func getFriendsIDs(withScreenName screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friends/ids.json"
-        
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["cursor"] ??= cursor
         parameters["stringify_ids"] ??= stringifyIDs
         parameters["count"] ??= count
@@ -90,25 +76,11 @@ public extension Swifter {
     
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getFollowersIDs(withId id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["cursor"] ??= cursor
-        parameters["stringify_ids"] ??= stringifyIDs
-        parameters["count"] ??= count
-        
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(ids: json["ids"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-            }, failure: failure)
-    }
-    
-    public func getFollowersIDs(withScreenName screenName: String, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "followers/ids.json"
-        
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["cursor"] ??= cursor
         parameters["stringify_ids"] ??= stringifyIDs
         parameters["count"] ??= count
@@ -161,23 +133,11 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postCreateFriendship(withId id: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postCreateFriendship(for userTag: UserTag, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["follow"] ??= follow
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postCreateFriendship(withScreenName screenName: String, follow: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friendships/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["follow"] ??= follow
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -194,22 +154,11 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postDestroyFriendship(withId id: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDestroyFriendship(for userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postDestroyFriendship(withScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friendships/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -221,24 +170,11 @@ public extension Swifter {
 
     Allows one to enable or disable retweets and device notifications from the specified user.
     */
-    public func postUpdateFriendship(withId id: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUpdateFriendship(for userTag: UserTag, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["device"] ??= device
-        parameters["retweets"] ??= retweets
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postUpdateFriendship(withScreenName screenName: String, device: Bool? = nil, retweets: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friendships/update.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["device"] ??= device
         parameters["retweets"] ??= retweets
 
@@ -252,26 +188,19 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func getFriendshipsShow(sourceID: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendshipsShow(source sourceTag: UserTag, target targetTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["source_id"] = sourceID
-        parameters["target_id"] ??= targetID
-        parameters["targetScreenName"] ??= targetScreenName
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getFriendshipsShow(sourceScreenName: String, targetID: String? = nil, orTargetScreenName targetScreenName: String? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friendships/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["source_screen_name"] = sourceScreenName
-        parameters["target_id"] ??= targetID
-        parameters["targetScreenName"] ??= targetScreenName
+        switch sourceTag {
+        case .id:           parameters["source_id"] = sourceTag.value
+        case .screenName:   parameters["source_screen_name"] = sourceTag.value
+        }
+        
+        switch targetTag {
+        case .id:           parameters["target_id"] = targetTag.value
+        case .screenName:   parameters["target_screen_name"] = targetTag.value
+        }
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -285,11 +214,11 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFriendsList(withId id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFriendsList(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
+        parameters[userTag.key] = userTag.value
         parameters["cursor"] ??= cursor
         parameters["count"] ??= count
         parameters["skip_status"] ??= skipStatus
@@ -297,22 +226,6 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-            }, failure: failure)
-    }
-
-    public func getFriendsList(withScreenName screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friends/list.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["cursor"] ??= cursor
-        parameters["count"] ??= count
-        parameters["skip_status"] ??= skipStatus
-        parameters["include_user_entities"] ??= includeUserEntities
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
             }, failure: failure)
     }
 
@@ -323,26 +236,11 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getFollowersList(withId id: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getFollowersList(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["cursor"] ??= cursor
-        parameters["count"] ??= count
-        parameters["skip_status"] ??= skipStatus
-        parameters["include_user_entities"] ??= includeUserEntities
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-            }, failure: failure)
-    }
-
-    public func getFollowersList(withScreenName screenName: String, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "followers/list.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["cursor"] ??= cursor
         parameters["count"] ??= count
         parameters["skip_status"] ??= skipStatus
@@ -358,23 +256,12 @@ public extension Swifter {
 
     Returns the relationships of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by, none.
     */
-    public func getFriendshipsLookup(withScreenNames screenNames: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
+    public func getFriendshipsLookup(for usersTag: UsersTag, success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
         let path = "friendships/lookup.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenNames.joined(separator: ",")
+        parameters[usersTag.key] = usersTag.value
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(friendships: json.array)
-            }, failure: failure)
-    }
-    
-    public func getFriendshipsLookup(withIds ids: [String], success: ((friendships: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "friendships/lookup.json"
-        
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = ids.joined(separator: ",")
-        
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(friendships: json.array)
             }, failure: failure)

--- a/Swifter/SwifterHelp.swift
+++ b/Swifter/SwifterHelp.swift
@@ -34,7 +34,7 @@ public extension Swifter {
 
     It is recommended applications request this endpoint when they are loaded, but no more than once a day.
     */
-    public func getHelpConfigurationWithSuccess(_ success: ((config: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getHelpConfiguration(success: ((config: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "help/configuration.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -47,7 +47,7 @@ public extension Swifter {
 
     Returns the list of languages supported by Twitter along with their ISO 639-1 code. The ISO 639-1 code is the two letter value to use if you include lang with any of your requests.
     */
-    public func getHelpLanguagesWithSuccess(_ success: ((languages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getHelpLanguages(success: ((languages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "help/languages.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -60,7 +60,7 @@ public extension Swifter {
 
     Returns Twitter's Privacy Policy.
     */
-    public func getHelpPrivacyWithSuccess(_ success: ((privacy: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getHelpPrivacy(success: ((privacy: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "help/privacy.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -73,7 +73,7 @@ public extension Swifter {
 
     Returns the Twitter Terms of Service in the requested format. These are not the same as the Developer Rules of the Road.
     */
-    public func getHelpTermsOfServiceWithSuccess(_ success: ((tos: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getHelpTermsOfService(success: ((tos: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "help/tos.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in

--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -36,7 +36,7 @@ public extension Swifter {
 
     A maximum of 100 results will be returned by this call. Subscribed lists are returned first, followed by owned lists. This means that if a user subscribes to 90 lists and owns 20 lists, this method returns 90 subscriptions and 10 owned lists. The reverse method returns owned lists first, so with reverse=true, 20 owned lists and 80 subscriptions would be returned. If your goal is to obtain every list a user owns or subscribes to, use GET lists/ownerships and/or GET lists/subscriptions instead.
     */
-    public func getListsSubscribedByUserWithReverse(_ reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribedByUserW(reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -47,7 +47,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribedByUserWithID(_ userID: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribedByUser(withId userID: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -59,7 +59,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribedByUserWithScreenName(_ screenName: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribedByUser(withScreenName screenName: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -76,7 +76,7 @@ public extension Swifter {
 
     Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great way to embed list timelines on your website.
     */
-    public func getListsStatusesWithListID(_ listID: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forListId listID: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -93,7 +93,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsStatusesWithListID(_ listID: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forListId listID: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -110,7 +110,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsStatusesWithSlug(_ slug: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forSlug slug: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -127,7 +127,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsStatusesWithSlug(_ slug: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forSlug slug: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -149,7 +149,7 @@ public extension Swifter {
 
     Removes the specified member from the list. The authenticated user must be the list's owner to remove members from the list.
     */
-    public func postListsMembersDestroyWithListID(_ listID: String, userID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forListId listID: String, userID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -161,7 +161,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyWithListID(_ listID: String, screenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forListId listID: String, screenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -173,7 +173,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyWithSlug(_ slug: String, userID: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forSlug slug: String, userID: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -186,7 +186,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyWithSlug(_ slug: String, screenName: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forSlug slug: String, screenName: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -199,7 +199,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyWithSlug(_ slug: String, userID: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forSlug slug: String, userID: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -212,7 +212,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyWithSlug(_ slug: String, screenName: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forSlug slug: String, screenName: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -230,7 +230,7 @@ public extension Swifter {
 
     Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
     */
-    public func getListsMembershipsWithUserID(_ userID: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMemberships(withUserId userID: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, Any>()
@@ -244,7 +244,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembershipsWithScreenName(_ screenName: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMemberships(withScreenName screenName: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, Any>()
@@ -264,7 +264,7 @@ public extension Swifter {
 
     Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsSubscribersWithListID(_ listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forListId listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -280,7 +280,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersWithListID(_ listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forListId listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -296,7 +296,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersWithSlug(_ slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forSlug slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -312,7 +312,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersWithSlug(_ slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forSlug slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -333,7 +333,7 @@ public extension Swifter {
 
     Subscribes the authenticated user to the specified list.
     */
-    public func postListsSubscribersCreateWithListID(_ listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forListId listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -345,7 +345,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersCreateWithListID(_ listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forListId listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -357,7 +357,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersCreateWithSlug(_ slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -369,7 +369,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersCreateWithSlug(_ slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -386,7 +386,7 @@ public extension Swifter {
 
     Check if the specified user is a subscriber of the specified list. Returns the user if they are subscriber.
     */
-    public func getListsSubscribersShowWithListID(_ listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forListId listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -401,7 +401,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShowWithListID(_ listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forListId listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -416,7 +416,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShowWithSlug(_ slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forSlug slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -432,7 +432,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShowWithSlug(_ slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forSlug slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -448,7 +448,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShowWithSlug(_ slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forSlug slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -464,7 +464,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShowWithSlug(_ slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forSlug slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -485,7 +485,7 @@ public extension Swifter {
 
     Unsubscribes the authenticated user from the specified list.
     */
-    public func postListsSubscribersDestroyWithListID(_ listID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(forListId listID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -496,7 +496,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersDestroyWithSlug(_ slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -508,7 +508,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersDestroyWithSlug(_ slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -527,7 +527,7 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersCreateWithListID(_ listID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forListId listID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -544,7 +544,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithListID(_ listID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forListId listID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -559,7 +559,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -577,7 +577,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -593,7 +593,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerScreenName: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -611,7 +611,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerScreenName: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -632,7 +632,7 @@ public extension Swifter {
 
     Check if the specified user is a member of the specified list.
     */
-    public func getListsMembersShowWithListID(_ listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forListId listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -646,7 +646,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersShowWithListID(_ listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forListId listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -660,7 +660,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersShowWithSlug(_ slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forSlug slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -675,7 +675,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersShowWithSlug(_ slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forSlug slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -690,7 +690,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersShowWithSlug(_ slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forSlug slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -710,7 +710,7 @@ public extension Swifter {
 
     Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsMembersShowWithSlug(_ slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forSlug slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -725,7 +725,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersWithListID(_ listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(forListId listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -741,7 +741,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersWithListID(_ listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(forListId listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -757,7 +757,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersWithSlug(_ slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(forSlug slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -773,7 +773,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersWithSlug(_ slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(forSlug slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -795,7 +795,7 @@ public extension Swifter {
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsMembersCreateWithListID(_ listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forListId listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -807,7 +807,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithListID(_ listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forListId listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -819,7 +819,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -831,7 +831,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreateWithSlug(_ slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -848,7 +848,7 @@ public extension Swifter {
 
     Deletes the specified list. The authenticated user must own the list to be able to destroy it.
     */
-    public func postListsDestroyWithListID(_ listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(forListId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -859,7 +859,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsDestroyWithSlug(_ slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(forSlug slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -871,7 +871,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsDestroyWithSlug(_ slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(forSlug slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -888,7 +888,7 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func postListsUpdateWithListID(_ listID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(forListId listID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -902,7 +902,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsUpdateWithSlug(_ slug: String, ownerID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(forSlug slug: String, ownerID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -917,7 +917,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsUpdateWithSlug(_ slug: String, ownerScreenName: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(forSlug slug: String, ownerScreenName: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -937,7 +937,7 @@ public extension Swifter {
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsCreateWithName(_ name: String, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsCreate(named name: String, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -955,7 +955,7 @@ public extension Swifter {
 
     Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsShowWithID(_ listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(forListId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -966,7 +966,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsShowWithSlug(_ slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(forSlug slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -978,7 +978,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsShowWithSlug(_ slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(forSlug slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -995,7 +995,7 @@ public extension Swifter {
 
     Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default. Does not include the user's own lists.
     */
-    public func getListsSubscriptionsWithUserID(_ userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscriptions(withUserId userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscriptions.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1009,7 +1009,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscriptionsWithScreenName(_ screenName: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscriptions(withScreenName screenName: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscriptions.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1030,7 +1030,7 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersDestroyAllWithListID(_ listID: String, userIDs: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forListId listID: String, userIDs: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1044,7 +1044,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyAllWithListID(_ listID: String, screenNames: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forListId listID: String, screenNames: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1056,7 +1056,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyAllWithSlug(_ slug: String, userIDs: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forSlug slug: String, userIDs: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1070,7 +1070,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyAllWithSlug(_ slug: String, screenNames: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forSlug slug: String, screenNames: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -1083,7 +1083,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func postListsMembersDestroyAllWithSlug(_ slug: String, userIDs: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forSlug slug: String, userIDs: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
         
         var parameters = Dictionary<String, Any>()
@@ -1098,7 +1098,7 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func postListsMembersDestroyAllWithSlug(_ slug: String, screenNames: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forSlug slug: String, screenNames: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
         
         var parameters = Dictionary<String, Any>()
@@ -1116,7 +1116,7 @@ public extension Swifter {
     
     Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
     */
-    public func getListsOwnershipsWithUserID(_ userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsOwnerships(withUserId userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/ownerships.json"
         
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -64,29 +64,14 @@ public extension Swifter {
 
     Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great way to embed list timelines on your website.
     */
-    public func getListsStatuses(forId listID: String, owner ownerTag: UserTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(for listTag: ListTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[ownerTag.ownerKey] = ownerTag.value
-        parameters["since_id"] ??= sinceID
-        parameters["max_id"] ??= maxID
-        parameters["count"] ??= count
-        parameters["include_entities"] ??= includeEntities
-        parameters["include_rts"] ??= includeRTs
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(statuses: json.array)
-            }, failure: failure)
-    }
-
-    public func getListsStatuses(forSlug slug: String, owner ownerTag: UserTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/statuses.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
         parameters["count"] ??= count
@@ -103,25 +88,15 @@ public extension Swifter {
 
     Removes the specified member from the list. The authenticated user must be the list's owner to remove members from the list.
     */
-    public func postListsMembersDestroy(forId listID: String, user userTag: UserTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(for listTag: ListTag, user userTag: UserTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters[userTag.key] = userTag.value
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroy(forSlug slug: String, user userTag: UserTag, owner ownerTag: UserTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[userTag.key] = userTag.value
-        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -152,12 +127,14 @@ public extension Swifter {
 
     Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsSubscribers(forId listID: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(for listTag: ListTag, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -168,45 +145,19 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribers(forSlug slug: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
     /**
     POST	lists/subscribers/create
 
     Subscribes the authenticated user to the specified list.
     */
-    public func postListsSubscribersCreate(forId listID: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(for listTag: ListTag, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[ownerTag.ownerKey] = ownerTag.value
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsSubscribersCreate(forSlug slug: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -218,28 +169,14 @@ public extension Swifter {
 
     Check if the specified user is a subscriber of the specified list. Returns the user if they are subscriber.
     */
-    public func getListsSubscribersShow(forId listID: String, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(for listTag: ListTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[userTag.key] = userTag.value
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribersShow(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[userTag.key] = userTag.value
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
 
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -254,23 +191,14 @@ public extension Swifter {
 
     Unsubscribes the authenticated user from the specified list.
     */
-    public func postListsSubscribersDestroy(forId listID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(for listTag: ListTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsSubscribersDestroy(forSlug slug: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -284,29 +212,16 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersCreate(forId listID: String, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(for listTag: ListTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters[usersTag.key] = usersTag.value
 
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, owner ownerTag: UserTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
-        parameters[usersTag.key] = usersTag.value
-        
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -320,26 +235,14 @@ public extension Swifter {
 
     Check if the specified user is a member of the specified list.
     */
-    public func getListsMembersShow(forId listID: String, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(for listTag: ListTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[userTag.key] = userTag.value
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsMembersShow(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -355,11 +258,14 @@ public extension Swifter {
     Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     */
 
-    public func getListsMembers(forId listID: String, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -370,45 +276,19 @@ public extension Swifter {
             }, failure: failure)
     }
     
-    public func getListsMembers(forSlug slug: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
     /**
     POST	lists/members/create
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsMembersCreate(forId listID: String, user userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(for listTag: ListTag, user userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters[userTag.key] = userTag.value
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -421,23 +301,14 @@ public extension Swifter {
 
     Deletes the specified list. The authenticated user must own the list to be able to destroy it.
     */
-    public func postListsDestroy(forId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(for listTag: ListTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsDestroy(forSlug slug: String, owner ownerTag: UserTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -449,28 +320,16 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func postListsUpdate(forId listID: String, name: String?, isPublic: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(for listTag: ListTag, name: String?, isPublic: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters["name"] ??= name
         parameters["mode"] = isPublic ? "public" : "private"
-        parameters["description"] ??= description
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsUpdate(forSlug slug: String, owner ownerTag: UserTag, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/update.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
-        parameters["name"] ??= name
-        parameters["mode"] = publicMode ? "public" : "private"
         parameters["description"] ??= description
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -501,23 +360,14 @@ public extension Swifter {
 
     Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsShow(forId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(for listTag: ListTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsShow(forSlug slug: String, owner ownerTag: UserTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -550,25 +400,15 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersDestroyAll(forId listID: String, users usersTag: UsersTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(for listTag: ListTag, users usersTag: UsersTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
+        parameters[listTag.key] = listTag.value
+        if case .slug(_, let owner) = listTag {
+            parameters[owner.ownerKey] = owner.value
+        }
         parameters[usersTag.key] = usersTag.value
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroyAll(forSlug slug: String, owner ownerTag: UserTag, users usersTag: UsersTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters[usersTag.key] = usersTag.value
-        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)

--- a/Swifter/SwifterLists.swift
+++ b/Swifter/SwifterLists.swift
@@ -47,23 +47,11 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribedByUser(withId userID: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribedByUser(for userTag: UserTag, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["userID"] = userID
-        parameters["reverse"] ??= reverse
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(lists: json.array)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribedByUser(withScreenName screenName: String, reverse: Bool?, success: ((lists: [JSON]?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/list.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["reverse"] ??= reverse
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -76,12 +64,12 @@ public extension Swifter {
 
     Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great way to embed list timelines on your website.
     */
-    public func getListsStatuses(forListId listID: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forId listID: String, owner ownerTag: UserTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["owner_screen_name"] = ownerScreenName
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
         parameters["count"] ??= count
@@ -93,46 +81,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsStatuses(forListId listID: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/statuses.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["owner_id"] = ownerID
-        parameters["since_id"] ??= sinceID
-        parameters["max_id"] ??= maxID
-        parameters["count"] ??= count
-        parameters["include_entities"] ??= includeEntities
-        parameters["include_rts"] ??= includeRTs
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(statuses: json.array)
-            }, failure: failure)
-    }
-
-    public func getListsStatuses(forSlug slug: String, ownerScreenName: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
+    public func getListsStatuses(forSlug slug: String, owner ownerTag: UserTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["since_id"] ??= sinceID
-        parameters["max_id"] ??= maxID
-        parameters["count"] ??= count
-        parameters["include_entities"] ??= includeEntities
-        parameters["include_rts"] ??= includeRTs
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(statuses: json.array)
-            }, failure: failure)
-    }
-
-    public func getListsStatuses(forSlug slug: String, ownerID: String, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: ((statuses: [JSON]?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/statuses.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
         parameters["count"] ??= count
@@ -149,76 +103,25 @@ public extension Swifter {
 
     Removes the specified member from the list. The authenticated user must be the list's owner to remove members from the list.
     */
-    public func postListsMembersDestroy(forListId listID: String, userID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forId listID: String, user userTag: UserTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)
             }, failure: failure)
     }
 
-    public func postListsMembersDestroy(forListId listID: String, screenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["screen_name"] = screenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroy(forSlug slug: String, userID: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroy(forSlug slug: String, user userTag: UserTag, owner ownerTag: UserTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["userID"] = userID
-        parameters["owner_screen_name"] = ownerScreenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroy(forSlug slug: String, screenName: String, ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["screen_name"] = screenName
-        parameters["owner_screen_name"] = ownerScreenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroy(forSlug slug: String, userID: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["userID"] = userID
-        parameters["owner_id"] = ownerID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroy(forSlug slug: String, screenName: String, ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["screen_name"] = screenName
-        parameters["owner_id"] = ownerID
+        parameters[userTag.key] = userTag.value
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)
@@ -230,26 +133,11 @@ public extension Swifter {
 
     Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
     */
-    public func getListsMemberships(withUserId userID: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMemberships(for userTag: UserTag, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
-        parameters["cursor"] ??= cursor
-        parameters["filter_to_owned_lists"] ??= filterToOwnedLists
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
-    public func getListsMemberships(withScreenName screenName: String, cursor: String?, filterToOwnedLists: Bool?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/memberships.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-
+        parameters[userTag.key] = userTag.value
         parameters["cursor"] ??= cursor
         parameters["filter_to_owned_lists"] ??= filterToOwnedLists
 
@@ -264,12 +152,12 @@ public extension Swifter {
 
     Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsSubscribers(forListId listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forId listID: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -280,44 +168,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribers(forListId listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["owner_id"] ??= ownerID
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
-    public func getListsSubscribers(forSlug slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribers(forSlug slug: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_screen_name"] ??= ownerScreenName
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
-    public func getListsSubscribers(forSlug slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] ??= ownerID
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -333,48 +189,24 @@ public extension Swifter {
 
     Subscribes the authenticated user to the specified list.
     */
-    public func postListsSubscribersCreate(forListId listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forId listID: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["owner_screen_name"] = ownerScreenName
         parameters["list_id"] = listID
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
             }, failure: failure)
     }
 
-    public func postListsSubscribersCreate(forListId listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersCreate(forSlug slug: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["owner_id"] = ownerID
-        parameters["list_id"] = listID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsSubscribersCreate(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["owner_screen_name"] = ownerScreenName
         parameters["slug"] = slug
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsSubscribersCreate(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["owner_id"] = ownerID
-        parameters["slug"] = slug
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -386,12 +218,12 @@ public extension Swifter {
 
     Check if the specified user is a subscriber of the specified list. Returns the user if they are subscriber.
     */
-    public func getListsSubscribersShow(forListId listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forId listID: String, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
 
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -401,76 +233,13 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsSubscribersShow(forListId listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["screen_name"] = screenName
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribersShow(forSlug slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscribersShow(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-        parameters["user_id"] = userID
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribersShow(forSlug slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-        parameters["screen_name"] = screenName
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribersShow(forSlug slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["user_id"] = userID
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsSubscribersShow(forSlug slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -485,7 +254,7 @@ public extension Swifter {
 
     Unsubscribes the authenticated user from the specified list.
     */
-    public func postListsSubscribersDestroy(forListId listID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(forId listID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -496,24 +265,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsSubscribersDestroy(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsSubscribersDestroy(forSlug slug: String, owner ownerTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsSubscribersDestroy(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -527,14 +284,12 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersCreate(forListId listID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forId listID: String, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
+        parameters[usersTag.key] = usersTag.value
 
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -544,81 +299,14 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsMembersCreate(forListId listID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerID: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersCreate(forSlug slug: String, owner ownerTag: UserTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerID: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, userIDs: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
-
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, screenNames: [String], includeEntities: Bool?, skipStatus: Bool?, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/create_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-
+        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[usersTag.key] = usersTag.value
+        
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -632,12 +320,12 @@ public extension Swifter {
 
     Check if the specified user is a member of the specified list.
     */
-    public func getListsMembersShow(forListId listID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forId listID: String, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -646,57 +334,13 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsMembersShow(forListId listID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsMembersShow(forSlug slug: String, ownerID: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembersShow(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-        parameters["user_id"] = userID
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsMembersShow(forSlug slug: String, ownerID: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsMembersShow(forSlug slug: String, ownerScreenName: String, userID: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["user_id"] = userID
+        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -710,27 +354,12 @@ public extension Swifter {
 
     Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsMembersShow(forSlug slug: String, ownerScreenName: String, screenName: String, includeEntities: Bool?, skipStatus: Bool?, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/show.json"
 
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsMembers(forListId listID: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsMembers(forId listID: String, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-        parameters["owner_screen_name"] ??= ownerScreenName
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -740,29 +369,13 @@ public extension Swifter {
 
             }, failure: failure)
     }
-
-    public func getListsMembers(forListId listID: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["owner_id"] ??= ownerID
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
-    public func getListsMembers(forSlug slug: String, ownerScreenName: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    
+    public func getListsMembers(forSlug slug: String, owner ownerTag: UserTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_screen_name"] ??= ownerScreenName
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["cursor"] ??= cursor
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
@@ -772,71 +385,31 @@ public extension Swifter {
 
             }, failure: failure)
     }
-
-    public func getListsMembers(forSlug slug: String, ownerID: String?, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_id"] ??= ownerID
-        parameters["cursor"] ??= cursor
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json["users"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
 
     /**
     POST	lists/members/create
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsMembersCreate(forListId listID: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
+    public func postListsMembersCreate(forId listID: String, user userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+        let path = "lists/members/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["owner_screen_name"] = ownerScreenName
         parameters["list_id"] = listID
+        parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
             }, failure: failure)
     }
 
-    public func postListsMembersCreate(forListId listID: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
+    public func postListsMembersCreate(forSlug slug: String, owner ownerTag: UserTag, user userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+        let path = "lists/members/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["owner_id"] = ownerID
-        parameters["list_id"] = listID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerScreenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["owner_screen_name"] = ownerScreenName
         parameters["slug"] = slug
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsMembersCreate(forSlug slug: String, ownerID: String, success: ((user: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscribers/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["owner_id"] = ownerID
-        parameters["slug"] = slug
+        parameters[ownerTag.ownerKey] = ownerTag.value
+        parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -848,7 +421,7 @@ public extension Swifter {
 
     Deletes the specified list. The authenticated user must own the list to be able to destroy it.
     */
-    public func postListsDestroy(forListId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(forId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -859,24 +432,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsDestroy(forSlug slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsDestroy(forSlug slug: String, owner ownerTag: UserTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
-    public func postListsDestroy(forSlug slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -888,13 +449,13 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func postListsUpdate(forListId listID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(forId listID: String, name: String?, isPublic: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
         parameters["name"] ??= name
-        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["mode"] = isPublic ? "public" : "private"
         parameters["description"] ??= description
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -902,12 +463,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postListsUpdate(forSlug slug: String, ownerID: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsUpdate(forSlug slug: String, owner ownerTag: UserTag, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
+        parameters[ownerTag.ownerKey] = ownerTag.value
         parameters["name"] ??= name
         parameters["mode"] = publicMode ? "public" : "private"
         parameters["description"] ??= description
@@ -916,33 +477,18 @@ public extension Swifter {
             success?(list: json.object)
             }, failure: failure)
     }
-
-    public func postListsUpdate(forSlug slug: String, ownerScreenName: String, name: String?, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/update.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
-        parameters["name"] ??= name
-        parameters["mode"] = publicMode ? "public" : "private"
-        parameters["description"] ??= description
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
+    
     /**
     POST	lists/create
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func postListsCreate(named name: String, publicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func postListsCreate(named name: String, isPublicMode: Bool = true, description: String?, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["name"] = name
-        parameters["mode"] = publicMode ? "public" : "private"
+        parameters["mode"] = isPublicMode ? "public" : "private"
         parameters["description"] ??= description
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -955,7 +501,7 @@ public extension Swifter {
 
     Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     */
-    public func getListsShow(forListId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(forId listID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -966,24 +512,12 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getListsShow(forSlug slug: String, ownerID: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
+    public func getListsShow(forSlug slug: String, owner ownerTag: UserTag, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["slug"] = slug
-        parameters["owner_id"] = ownerID
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(list: json.object)
-            }, failure: failure)
-    }
-
-    public func getListsShow(forSlug slug: String, ownerScreenName: String, success: ((list: Dictionary<String, JSON>?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["owner_screen_name"] = ownerScreenName
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(list: json.object)
@@ -995,11 +529,11 @@ public extension Swifter {
 
     Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default. Does not include the user's own lists.
     */
-    public func getListsSubscriptions(withUserId userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsSubscriptions(for userTag: UserTag, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/subscriptions.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
         parameters["count"] ??= count
         parameters["cursor"] ??= cursor
 
@@ -1008,21 +542,7 @@ public extension Swifter {
 
             }, failure: failure)
     }
-
-    public func getListsSubscriptions(withScreenName screenName: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/subscriptions.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["count"] ??= count
-        parameters["cursor"] ??= cursor
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(lists: json["lists"].array, previousCursor: json["previous_cursor_str"].string, nextCursor: json["next_cursor_str"].string)
-
-            }, failure: failure)
-    }
-
+    
     /**
     POST	lists/members/destroy_all
 
@@ -1030,83 +550,27 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func postListsMembersDestroyAll(forListId listID: String, userIDs: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forId listID: String, users usersTag: UsersTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["list_id"] = listID
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
+        parameters[usersTag.key] = usersTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)
             }, failure: failure)
     }
 
-    public func postListsMembersDestroyAll(forListId listID: String, screenNames: [String], success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
+    public func postListsMembersDestroyAll(forSlug slug: String, owner ownerTag: UserTag, users usersTag: UsersTag, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["list_id"] = listID
-        parameters["screen_name"] = screenNames.joined(separator: ",")
+        parameters["slug"] = slug
+        parameters[usersTag.key] = usersTag.value
+        parameters[ownerTag.ownerKey] = ownerTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroyAll(forSlug slug: String, userIDs: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
-        parameters["owner_screen_name"] = ownerScreenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(response: json)
-            }, failure: failure)
-    }
-
-    public func postListsMembersDestroyAll(forSlug slug: String, screenNames: [String], ownerScreenName: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy_all.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-        parameters["owner_screen_name"] = ownerScreenName
-        
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(response: json)
-            }, failure: failure)
-    }
-    
-    public func postListsMembersDestroyAll(forSlug slug: String, userIDs: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy_all.json"
-        
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
-        parameters["owner_id"] = ownerID
-        
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(response: json)
-            }, failure: failure)
-    }
-    
-    public func postListsMembersDestroyAll(forSlug slug: String, screenNames: [String], ownerID: String, success: ((response: JSON?) -> Void)?, failure: FailureHandler?) {
-        let path = "lists/members/destroy_all.json"
-        
-        var parameters = Dictionary<String, Any>()
-        parameters["slug"] = slug
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-        parameters["owner_id"] = ownerID
-        
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(response: json)
             }, failure: failure)
     }
@@ -1116,11 +580,11 @@ public extension Swifter {
     
     Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
     */
-    public func getListsOwnerships(withUserId userID: String, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
+    public func getListsOwnerships(for userTag: UserTag, count: String?, cursor: String?, success: ((lists: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?) {
         let path = "lists/ownerships.json"
         
         var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
         parameters["count"] ??= count
         parameters["cursor"] ??= cursor
         
@@ -1129,6 +593,17 @@ public extension Swifter {
 
             }, failure: failure)
         
+    }
+    
+}
+
+private extension UserTag {
+    
+    var ownerKey: String {
+        switch self {
+        case .id:           return "owner_id"
+        case .screenName:   return "owner_screen_name"
+        }
     }
     
 }

--- a/Swifter/SwifterMessages.swift
+++ b/Swifter/SwifterMessages.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns the 20 most recent direct messages sent to the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 incoming DMs.
     */
-    public func getDirectMessagesSinceID(_ sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages.json"
 
         var parameters = Dictionary<String, Any>()
@@ -52,7 +52,7 @@ public extension Swifter {
 
     Returns the 20 most recent direct messages sent by the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 outgoing DMs.
     */
-    public func getSentDirectMessagesSinceID(_ sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, page: Int? = nil, includeEntities: Bool? = nil, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getSentDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, page: Int? = nil, includeEntities: Bool? = nil, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/sent.json"
 
         var parameters = Dictionary<String, Any>()
@@ -72,7 +72,7 @@ public extension Swifter {
 
     Returns a single direct message, specified by an id parameter. Like the /1.1/direct_messages.format request, this method will include the user objects of the sender and recipient.
     */
-    public func getDirectMessagesShowWithID(_ id: String, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getDirectMessagesShow(with id: String, success: ((messages: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/show.json"
         let parameters: [String: Any] = ["id" : id]
 
@@ -86,7 +86,7 @@ public extension Swifter {
 
     Destroys the direct message specified in the required ID parameter. The authenticating user must be the recipient of the specified direct message.
     */
-    public func postDestroyDirectMessageWithID(_ id: String, includeEntities: Bool? = nil, success: ((messages: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDestroyDirectMessage(with id: String, includeEntities: Bool? = nil, success: ((messages: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -103,7 +103,7 @@ public extension Swifter {
 
     Sends a new direct message to the specified user from the authenticating user. Requires both the user and text parameters and must be a POST. Returns the sent message in the requested format if successful.
     */
-    public func postDirectMessageToUser(_ userID: String, text: String, success: ((statuses: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postDirectMessage(to userID: String, text: String, success: ((statuses: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/new.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterOAuthClient.swift
+++ b/Swifter/SwifterOAuthClient.swift
@@ -60,7 +60,7 @@ internal class OAuthClient: SwifterClientProtocol  {
         let url = URL(string: path, relativeTo: baseURL.url)!
 
         let request = HTTPRequest(url: url, method: .GET, parameters: parameters)
-        request.headers = ["Authorization": self.authorizationHeaderForMethod(.GET, url: url, parameters: parameters, isMediaUpload: false)]
+        request.headers = ["Authorization": self.authorizationHeader(for: .GET, url: url, parameters: parameters, isMediaUpload: false)]
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure
@@ -96,7 +96,7 @@ internal class OAuthClient: SwifterClientProtocol  {
         }
 
         let request = HTTPRequest(url: url, method: .POST, parameters: parameters)
-        request.headers = ["Authorization": self.authorizationHeaderForMethod(.POST, url: url, parameters: parameters, isMediaUpload: postData != nil)]
+        request.headers = ["Authorization": self.authorizationHeader(for: .POST, url: url, parameters: parameters, isMediaUpload: postData != nil)]
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure
@@ -112,7 +112,7 @@ internal class OAuthClient: SwifterClientProtocol  {
         return request
     }
 
-    func authorizationHeaderForMethod(_ method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, isMediaUpload: Bool) -> String {
+    func authorizationHeader(for method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, isMediaUpload: Bool) -> String {
         var authorizationParameters = Dictionary<String, Any>()
         authorizationParameters["oauth_version"] = OAuth.version
         authorizationParameters["oauth_signature_method"] =  OAuth.signatureMethod
@@ -130,7 +130,7 @@ internal class OAuthClient: SwifterClientProtocol  {
 
         let finalParameters = isMediaUpload ? authorizationParameters : combinedParameters
 
-        authorizationParameters["oauth_signature"] = self.oauthSignatureForMethod(method, url: url, parameters: finalParameters, accessToken: self.credential?.accessToken)
+        authorizationParameters["oauth_signature"] = self.oauthSignature(for: method, url: url, parameters: finalParameters, accessToken: self.credential?.accessToken)
 
         let authorizationParameterComponents = authorizationParameters.urlEncodedQueryString(using: self.dataEncoding).components(separatedBy: "&").sorted()
 
@@ -145,7 +145,7 @@ internal class OAuthClient: SwifterClientProtocol  {
         return "OAuth " + headerComponents.joined(separator: ", ")
     }
 
-    func oauthSignatureForMethod(_ method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, accessToken token: Credential.OAuthAccessToken?) -> String {
+    func oauthSignature(for method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, accessToken token: Credential.OAuthAccessToken?) -> String {
         let tokenSecret = token?.secret.urlEncodedString ?? ""
         let encodedConsumerSecret = self.consumerSecret.urlEncodedString
         let signingKey = "\(encodedConsumerSecret)&\(tokenSecret)"

--- a/Swifter/SwifterPlaces.swift
+++ b/Swifter/SwifterPlaces.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns all the information about a known place.
     */
-    public func getGeoIDWithPlaceID(_ placeID: String, success: ((place: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getGeoID(for placeID: String, success: ((place: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "geo/id/\(placeID).json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -47,7 +47,7 @@ public extension Swifter {
 
     This request is an informative call and will deliver generalized results about geography.
     */
-    public func getGeoReverseGeocodeWithLat(_ lat: Double, long: Double, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, callback: String? = nil, success: ((place: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getGeoReverseGeocode(lat: Double, long: Double, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, callback: String? = nil, success: ((place: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "geo/reverse_geocode.json"
 
         var parameters = Dictionary<String, Any>()
@@ -73,7 +73,7 @@ public extension Swifter {
 
     This is the recommended method to use find places that can be attached to statuses/update. Unlike GET geo/reverse_geocode which provides raw data access, this endpoint can potentially re-order places with regards to the user who is authenticated. This approach is also preferred for interactive place matching with the user.
     */
-    public func getGeoSearchWithLat(_ lat: Double? = nil, long: Double? = nil, query: String? = nil, ipAddress: String? = nil, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: ((places: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getGeoSearch(lat: Double? = nil, long: Double? = nil, query: String? = nil, ipAddress: String? = nil, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: ((places: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         assert(lat != nil || long != nil || query != nil || ipAddress != nil, "At least one of the following parameters must be provided to access this resource: lat, long, ipAddress, or query")
 
         let path = "geo/search.json"
@@ -104,7 +104,7 @@ public extension Swifter {
 
     The token contained in the response is the token needed to be able to create a new place.
     */
-    public func getGeoSimilarPlacesWithLat(_ lat: Double, long: Double, name: String, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: ((places: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getGeoSimilarPlaces(lat: Double, long: Double, name: String, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: ((places: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "geo/similar_places.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterSavedSearches.swift
+++ b/Swifter/SwifterSavedSearches.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns the authenticated user's saved search queries.
     */
-    public func getSavedSearchesListWithSuccess(_ success: ((savedSearches: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getSavedSearchesList(success: ((savedSearches: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/list.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -45,7 +45,7 @@ public extension Swifter {
 
     Retrieve the information for the saved search represented by the given id. The authenticating user must be the owner of saved search ID being requested.
     */
-    public func getSavedSearchesShowWithID(_ id: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getSavedSearchesShow(for id: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/show/\(id).json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -58,7 +58,7 @@ public extension Swifter {
 
     Create a new saved search for the authenticated user. A user may only have 25 saved searches.
     */
-    public func postSavedSearchesCreateShowWithQuery(_ query: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postSavedSearchesCreateShow(query: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -74,7 +74,7 @@ public extension Swifter {
 
     Destroys a saved search for the authenticating user. The authenticating user must be the owner of saved search id being destroyed.
     */
-    public func postSavedSearchesDestroyWithID(_ id: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postSavedSearchesDestroy(with id: String, success: ((savedSearch: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/destroy/\(id).json"
 
         self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in

--- a/Swifter/SwifterSearch.swift
+++ b/Swifter/SwifterSearch.swift
@@ -37,7 +37,7 @@ public extension Swifter {
      In API v1.1, the response format of the Search API has been improved to return Tweet objects more similar to the objects you’ll find across the REST API and platform. However, perspectival attributes (fields that pertain to the perspective of the authenticating user) are not currently supported on this endpoint.
 
      */
-    public func getSearchTweetsWithQuery(_ q: String, geocode: String? = nil, lang: String? = nil, locale: String? = nil, resultType: String? = nil, count: Int? = nil, until: String? = nil, sinceID: String? = nil, maxID: String? = nil, includeEntities: Bool? = nil, callback: String? = nil, success: ((statuses: [JSON]?, searchMetadata: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func getSearchTweets(with q: String, geocode: String? = nil, lang: String? = nil, locale: String? = nil, resultType: String? = nil, count: Int? = nil, until: String? = nil, sinceID: String? = nil, maxID: String? = nil, includeEntities: Bool? = nil, callback: String? = nil, success: ((statuses: [JSON]?, searchMetadata: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "search/tweets.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterSpam.swift
+++ b/Swifter/SwifterSpam.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST blocks/create on behalf of the authenticated user.
     */
-    public func postUsersReportSpamWithScreenName(_ screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUsersReportSpam(withScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/report_spam.json"
 
         var parameters = Dictionary<String, Any>()
@@ -43,7 +43,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postUsersReportSpamWithUserID(_ userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUsersReportSpam(withUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/report_spam.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterSpam.swift
+++ b/Swifter/SwifterSpam.swift
@@ -32,22 +32,9 @@ public extension Swifter {
 
     Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST blocks/create on behalf of the authenticated user.
     */
-    public func postUsersReportSpam(withScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postUsersReportSpam(for userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/report_spam.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postUsersReportSpam(withUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "users/report_spam.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        let parameters: [String: Any] = [userTag.key: userTag.value]
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)

--- a/Swifter/SwifterStreaming.swift
+++ b/Swifter/SwifterStreaming.swift
@@ -38,7 +38,7 @@ public extension Swifter {
 
     At least one predicate parameter (follow, locations, or track) must be specified.
     */
-    public func postStatusesFilterWithFollow(_ follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>? ) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func postStatusesFilter(with follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>? ) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         assert(follow != nil || track != nil || locations != nil, "At least one predicate parameter (follow, locations, or track) must be specified")
 
         let path = "statuses/filter.json"
@@ -69,7 +69,7 @@ public extension Swifter {
 
     Returns a small random sample of all public statuses. The Tweets returned by the default access level are the same, so if two different clients connect to this endpoint, they will see the same Tweets.
     */
-    public func getStatusesSampleDelimited(_ delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func getStatusesSample(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/sample.json"
 
         var parameters = Dictionary<String, Any>()
@@ -97,7 +97,7 @@ public extension Swifter {
 
     Returns all public statuses. Few applications require this level of access. Creative use of a combination of other resources and various access levels can satisfy nearly every application use case.
     */
-    public func getStatusesFirehose(_ count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func getStatusesFirehose(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/firehose.json"
 
         var parameters = Dictionary<String, Any>()
@@ -124,7 +124,7 @@ public extension Swifter {
 
     Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func getUserStreamDelimited(_ delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func getUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
@@ -155,7 +155,7 @@ public extension Swifter {
 
     Streams messages for a set of users, as described in Site streams https://dev.twitter.com/docs/streaming-apis/streams/site
     */
-    public func getSiteStreamDelimited(_ delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func getSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: ((status: Dictionary<String, JSON>?) -> Void)? = nil, stallWarningHandler: ((code: String?, message: String?, percentFull: Int?) -> Void)? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "site.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterSuggested.swift
+++ b/Swifter/SwifterSuggested.swift
@@ -34,7 +34,7 @@ public extension Swifter {
 
     It is recommended that applications cache this data for no more than one hour.
     */
-    public func getUsersSuggestionsWithSlug(_ slug: String, lang: String? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(slug: String, lang: String? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions/\(slug).json"
 
         var parameters = Dictionary<String, Any>()
@@ -50,7 +50,7 @@ public extension Swifter {
 
     Access to Twitter's suggested user list. This returns the list of suggested user categories. The category can be used in GET users/suggestions/:slug to get the users in that category.
     */
-    public func getUsersSuggestionsWithLang(_ lang: String? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(lang: String? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions.json"
 
         var parameters = Dictionary<String, Any>()
@@ -66,7 +66,7 @@ public extension Swifter {
 
     Access the users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user.
     */
-    public func getUsersSuggestionsForSlugMembers(_ slug: String, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(for slug: String, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions/\(slug)/members.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in

--- a/Swifter/SwifterTag.swift
+++ b/Swifter/SwifterTag.swift
@@ -46,4 +46,22 @@ public enum UsersTag {
     }
 }
 
+public enum ListTag {
+    case id(String)
+    case slug(String, owner: UserTag)
+    
+    var key: String {
+        switch self {
+        case .id:   return "list_id"
+        case .slug: return "slug"
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .id(let id):           return id
+        case .slug(let slug, _):    return slug
+        }
+    }
+    
 }

--- a/Swifter/SwifterTag.swift
+++ b/Swifter/SwifterTag.swift
@@ -1,0 +1,49 @@
+//
+//  SwifterTag.swift
+//  Swifter
+//
+//  Created by Andy on 7/30/16.
+//  Copyright © 2016 Matt Donnelly. All rights reserved.
+//
+
+import Foundation
+
+public enum UserTag {
+    case id(String)
+    case screenName(String)
+    
+    var key: String {
+        switch self {
+        case .id:           return "user_id"
+        case .screenName:   return "screen_name"
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .id(let id):           return id
+        case .screenName(let user): return user
+        }
+    }
+}
+
+public enum UsersTag {
+    case id([String])
+    case screenName([String])
+    
+    var key: String {
+        switch self {
+        case .id:           return "user_id"
+        case .screenName:   return "screen_name"
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .id(let id):           return id.joined(separator: ",")
+        case .screenName(let user): return user.joined(separator: ",")
+        }
+    }
+}
+
+}

--- a/Swifter/SwifterTimelines.swift
+++ b/Swifter/SwifterTimelines.swift
@@ -28,7 +28,7 @@ import Foundation
 public extension Swifter {
 
     // Convenience method
-    private func getTimelineAtPath(_ path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    private func getTimeline(at path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         var params = parameters
         params["count"] ??= count
         params["since_id"] ??= sinceID
@@ -52,8 +52,8 @@ public extension Swifter {
 
     This method can only return up to 800 tweets.
     */
-    public func getStatusesMentionTimelineWithCount(_ count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
-        self.getTimelineAtPath("statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getStatusesMentionTimeline(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler?) {
+        self.getTimeline(at: "statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 
 
@@ -69,10 +69,10 @@ public extension Swifter {
 
     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
     */
-    public func getStatusesUserTimelineWithUserID(_ userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesUserTimeline(for userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let parameters: Dictionary<String, Any> = ["user_id": userID]
 
-        self.getTimelineAtPath("statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+        self.getTimeline(at: "statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 
     /**
@@ -84,8 +84,8 @@ public extension Swifter {
 
     Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow many users or follow users who tweet frequently.
     */
-    public func getStatusesHomeTimelineWithCount(_ count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        self.getTimelineAtPath("statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getStatusesHomeTimeline(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+        self.getTimeline(at: "statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 
     /**
@@ -93,8 +93,8 @@ public extension Swifter {
 
     Returns the most recent tweets authored by the authenticating user that have been retweeted by others. This timeline is a subset of the user's GET statuses/user_timeline. See Working with Timelines for instructions on traversing timelines.
     */
-    public func getStatusesRetweetsOfMeWithCount(_ count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        self.getTimelineAtPath("statuses/retweets_of_me.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getStatusesRetweetsOfMe(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+        self.getTimeline(at: "statuses/retweets_of_me.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 
 }

--- a/Swifter/SwifterTrends.swift
+++ b/Swifter/SwifterTrends.swift
@@ -19,11 +19,11 @@ public extension Swifter {
 
     This information is cached for 5 minutes. Requesting more frequently than that will not return any more data, and will count against your rate limit usage.
     */
-    public func getTrendsPlaceWithWOEID(_ id: String, excludeHashtags: Bool = false, success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsPlace(with woeid: String, excludeHashtags: Bool = false, success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "trends/place.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
+        parameters["id"] = woeid
         parameters["exclude"] = excludeHashtags ? "hashtags" : nil
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
@@ -40,7 +40,7 @@ public extension Swifter {
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getTrendsAvailableWithSuccess(_ success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsAvailable(success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "trends/available.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -57,7 +57,7 @@ public extension Swifter {
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getTrendsClosestWithLat(_ lat: Double, long: Double, success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsClosest(lat: Double, long: Double, success: ((trends: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "trends/closest.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterTweets.swift
+++ b/Swifter/SwifterTweets.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns up to 100 of the first retweets of a given tweet.
     */
-    public func getStatusesRetweetsWithID(_ id: String, count: Int? = nil, trimUser: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesRetweets(with id: String, count: Int? = nil, trimUser: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweets/\(id).json"
 
         var parameters = Dictionary<String, Any>()
@@ -63,7 +63,7 @@ public extension Swifter {
 
     This object contains an array of user IDs for users who have contributed to this status (an example of a status that has been contributed to is this one). In practice, there is usually only one ID in this array. The JSON renders as such "contributors":[8285392].
     */
-    public func getStatusesShowWithID(_ id: String, count: Int? = nil, trimUser: Bool? = nil, includeMyRetweet: Bool? = nil, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesShow(with id: String, count: Int? = nil, trimUser: Bool? = nil, includeMyRetweet: Bool? = nil, includeEntities: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -83,7 +83,7 @@ public extension Swifter {
 
     Destroys the status specified by the required ID parameter. The authenticating user must be the author of the specified status. Returns the destroyed status if successful.
     */
-    public func postStatusesDestroyWithID(_ id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postStatusesDestroy(with id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/destroy/\(id).json"
 
         var parameters = Dictionary<String, Any>()
@@ -198,7 +198,7 @@ public extension Swifter {
 
     Returns Tweets (1: the new tweet)
     */
-    public func postStatusRetweetWithID(_ id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postStatusRetweet(with id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweet/\(id).json"
 
         var parameters = Dictionary<String, Any>()
@@ -221,7 +221,7 @@ public extension Swifter {
      
      Returns Tweets (1: the original tweet)
      */
-    public func postStatusUnretweetWithID(_ id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postStatusUnretweet(with id: String, trimUser: Bool? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/unretweet/\(id).json"
         
         var parameters = Dictionary<String, Any>()
@@ -239,7 +239,7 @@ public extension Swifter {
 
     While this endpoint allows a bit of customization for the final appearance of the embedded Tweet, be aware that the appearance of the rendered Tweet may change over time to be consistent with Twitter's Display Requirements. Do not rely on any class or id parameters to stay constant in the returned markup.
     */
-    public func getStatusesOEmbedWithID(_ id: String, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesOEmbed(withId id: String, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -257,7 +257,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getStatusesOEmbedWithURL(_ url: URL, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesOEmbed(withUrl url: URL, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: ((status: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -282,7 +282,7 @@ public extension Swifter {
 
     This method offers similar data to GET statuses/retweets/:id and replaces API v1's GET statuses/:id/retweeted_by/ids method.
     */
-    public func getStatusesRetweetersWithID(_ id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesRetweeters(with id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweeters/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -300,7 +300,7 @@ public extension Swifter {
 
     Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by comma-separated values passed to the id parameter. This method is especially useful to get the details (hydrate) a collection of Tweet IDs. GET statuses/show/:id is used to retrieve a single tweet object.
     */
-    public func getStatusesLookupTweetIDs(_ tweetIDs: [String], includeEntities: Bool? = nil, map: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getStatusesLookup(for tweetIDs: [String], includeEntities: Bool? = nil, map: Bool? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/lookup.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -223,24 +223,11 @@ public extension Swifter {
 
     Blocks the specified user from following the authenticating user. In addition the blocked user will not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend relationship exists it is destroyed.
     */
-    public func postBlocksCreate(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postBlocksCreate(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/create.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postBlocksCreate(withUserId userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
-        let path = "blocks/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -254,24 +241,11 @@ public extension Swifter {
 
     Un-blocks the user specified in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format when successful. If relationships existed before the block was instated, they will not be restored.
     */
-    public func postDestroyBlocks(withUserId userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postDestroyBlocks(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postDestroyBlocks(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
-        let path = "blocks/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
+        parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
@@ -297,25 +271,11 @@ public extension Swifter {
     - If none of your lookup criteria can be satisfied by returning a user object, a HTTP 404 will be thrown.
     - You are strongly encouraged to use a POST for larger requests.
     */
-    public func getUsersLookup(withScreenNames screenNames: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersLookup(for usersTag: UsersTag, includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenNames.joined(separator: ",")
-        parameters["include_entities"] ??= includeEntities
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json.array)
-            }, failure: failure)
-    }
-
-    public func getUsersLookup(withUserIds userIDs: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
-        let path = "users/lookup.json"
-
-        var parameters = Dictionary<String, Any>()
-
-        let userIDStrings = userIDs.map { String($0) }
-        parameters["user_id"] = userIDStrings.joined(separator: ",")
+        parameters[usersTag.key] = usersTag.value
         parameters["include_entities"] ??= includeEntities
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -330,23 +290,11 @@ public extension Swifter {
 
     You must be following a protected user to be able to see their most recent Tweet. If you don't follow a protected user, the users Tweet will be removed. A Tweet will not always be returned in the current_status field.
     */
-    public func getUsersShow(withScreenName screenName: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersShow(for userTag: UserTag, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/show.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func getUsersShow(withUserId userID: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
-        let path = "users/show.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
@@ -369,37 +317,6 @@ public extension Swifter {
         parameters["page"] ??= page
         parameters["count"] ??= count
         parameters["include_entities"] ??= includeEntities
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json.array)
-            }, failure: failure)
-    }
-
-    /**
-    GET    users/contributees
-
-    Returns a collection of users that the specified user can "contribute" to.
-    */
-    public func getUsersContributees(withUserId id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "users/contributees.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json.array)
-            }, failure: failure)
-    }
-
-    public func getUsersContributees(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "users/contributees.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(users: json.array)
@@ -454,10 +371,11 @@ public extension Swifter {
 
     Returns a map of the available size variations of the specified user's profile banner. If the user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string manipulation on the profile_banner_url returned in user objects as described in User Profile Images and Banners.
     */
-    public func getUsersProfileBanner(withUserId userID: String, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersProfileBanner(for userTag: UserTag, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/profile_banner.json"
+        let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(response: json)
             }, failure: failure)
     }
@@ -471,22 +389,9 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postMutesUsersCreate(forScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersCreate(for userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postMutesUsersCreate(forUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "mutes/users/create.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        let parameters: [String: Any] = [userTag.key: userTag.value]
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)
@@ -502,22 +407,11 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postMutesUsersDestroy(forScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersDestroy(for userTag: UserTag, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/destroy.json"
 
         var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(user: json.object)
-            }, failure: failure)
-    }
-
-    public func postMutesUsersDestroy(forUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "mutes/users/destroy.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["user_id"] = userID
+        parameters[userTag.key] = userTag.value
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(user: json.object)

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -407,37 +407,6 @@ public extension Swifter {
     }
 
     /**
-    GET    users/contributors
-
-    Returns a collection of users who can contribute to the specified account.
-    */
-    public func getUsersContributors(withUserId id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "users/contributors.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["id"] = id
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json.array)
-            }, failure: failure)
-    }
-
-    public func getUsersContributors(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
-        let path = "users/contributors.json"
-
-        var parameters = Dictionary<String, Any>()
-        parameters["screen_name"] = screenName
-        parameters["include_entities"] ??= includeEntities
-        parameters["skip_status"] ??= skipStatus
-
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(users: json.array)
-            }, failure: failure)
-    }
-
-    /**
     POST   account/remove_profile_banner
 
     Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon success.

--- a/Swifter/SwifterUsers.swift
+++ b/Swifter/SwifterUsers.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns settings (including current trend, geo and sleep time information) for the authenticating user.
     */
-    public func getAccountSettingsWithSuccess(_ success: ((settings: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getAccountSettings(success: ((settings: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/settings.json"
 
         self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -45,7 +45,7 @@ public extension Swifter {
 
     Returns an HTTP 200 OK response code and a representation of the requesting user if authentication was successful; returns a 401 status code and an error message if not. Use this method to test if supplied user credentials are valid.
     */
-    public func getAccountVerifyCredentials(_ includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((myInfo: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getAccountVerifyCredentials(includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((myInfo: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/verify_credentials.json"
 
         var parameters = Dictionary<String, Any>()
@@ -62,7 +62,7 @@ public extension Swifter {
 
     Updates the authenticating user's settings.
     */
-    public func postAccountSettings(_ trendLocationWOEID: String? = nil, sleepTimeEnabled: Bool? = nil, startSleepTime: Int? = nil, endSleepTime: Int? = nil, timeZone: String? = nil, lang: String? = nil, success: ((settings: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountSettings(trendLocationWOEID: String? = nil, sleepTimeEnabled: Bool? = nil, startSleepTime: Int? = nil, endSleepTime: Int? = nil, timeZone: String? = nil, lang: String? = nil, success: ((settings: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         assert(trendLocationWOEID != nil || sleepTimeEnabled != nil || startSleepTime != nil || endSleepTime != nil || timeZone != nil || lang != nil, "At least one or more should be provided when executing this request")
 
         let path = "account/settings.json"
@@ -102,7 +102,7 @@ public extension Swifter {
 
     Sets values that users are able to set under the "Account" tab of their settings page. Only the parameters specified will be updated.
     */
-    public func postAccountUpdateProfileWithName(_ name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((profile: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountUpdateProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((profile: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         assert(name != nil || url != nil || location != nil || description != nil || includeEntities != nil || skipStatus != nil)
 
         let path = "account/update_profile.json"
@@ -188,7 +188,7 @@ public extension Swifter {
 
     Returns a collection of user objects that the authenticating user is blocking.
     */
-    public func getBlockListWithIncludeEntities(_ includeEntities: Bool? = nil, skipStatus: Bool? = nil, cursor: String? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getBlockList(includeEntities: Bool? = nil, skipStatus: Bool? = nil, cursor: String? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "blocks/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -206,7 +206,7 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user is blocking.
     */
-    public func getBlockIDsWithStingifyIDs(_ stringifyIDs: String? = nil, cursor: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler) {
+    public func getBlockIDs(stringifyIDs: String? = nil, cursor: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -223,7 +223,7 @@ public extension Swifter {
 
     Blocks the specified user from following the authenticating user. In addition the blocked user will not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend relationship exists it is destroyed.
     */
-    public func postBlocksCreateWithScreenName(_ screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postBlocksCreate(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -236,7 +236,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postBlocksCreateWithUserID(_ userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postBlocksCreate(withUserId userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -254,7 +254,7 @@ public extension Swifter {
 
     Un-blocks the user specified in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format when successful. If relationships existed before the block was instated, they will not be restored.
     */
-    public func postDestroyBlocksWithUserID(_ userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postDestroyBlocks(withUserId userID: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -267,7 +267,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postDestroyBlocksWithScreenName(_ screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func postDestroyBlocks(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "blocks/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -297,7 +297,7 @@ public extension Swifter {
     - If none of your lookup criteria can be satisfied by returning a user object, a HTTP 404 will be thrown.
     - You are strongly encouraged to use a POST for larger requests.
     */
-    public func getUsersLookupWithScreenNames(_ screenNames: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersLookup(withScreenNames screenNames: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -309,7 +309,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getUsersLookupWithUserIDs(_ userIDs: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersLookup(withUserIds userIDs: [String], includeEntities: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -330,7 +330,7 @@ public extension Swifter {
 
     You must be following a protected user to be able to see their most recent Tweet. If you don't follow a protected user, the users Tweet will be removed. A Tweet will not always be returned in the current_status field.
     */
-    public func getUsersShowWithScreenName(_ screenName: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersShow(withScreenName screenName: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -342,7 +342,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getUsersShowWithUserID(_ userID: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersShow(withUserId userID: String, includeEntities: Bool? = nil, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -361,7 +361,7 @@ public extension Swifter {
 
     Only the first 1,000 matching results are available.
     */
-    public func getUsersSearchWithQuery(_ q: String, page: Int?, count: Int?, includeEntities: Bool?, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
+    public func getUsersSearch(with q: String, page: Int?, count: Int?, includeEntities: Bool?, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler) {
         let path = "users/search.json"
 
         var parameters = Dictionary<String, Any>()
@@ -380,7 +380,7 @@ public extension Swifter {
 
     Returns a collection of users that the specified user can "contribute" to.
     */
-    public func getUsersContributeesWithUserID(_ id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersContributees(withUserId id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/contributees.json"
 
         var parameters = Dictionary<String, Any>()
@@ -393,7 +393,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getUsersContributeesWithScreenName(_ screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersContributees(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/contributees.json"
 
         var parameters = Dictionary<String, Any>()
@@ -411,7 +411,7 @@ public extension Swifter {
 
     Returns a collection of users who can contribute to the specified account.
     */
-    public func getUsersContributorsWithUserID(_ id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersContributors(withUserId id: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/contributors.json"
 
         var parameters = Dictionary<String, Any>()
@@ -424,7 +424,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func getUsersContributorsWithScreenName(_ screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersContributors(withScreenName screenName: String, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/contributors.json"
 
         var parameters = Dictionary<String, Any>()
@@ -442,7 +442,7 @@ public extension Swifter {
 
     Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon success.
     */
-    public func postAccountRemoveProfileBannerWithSuccess(_ success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountRemoveProfileBanner(success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/remove_profile_banner.json"
 
         self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -464,7 +464,7 @@ public extension Swifter {
     400	Either an image was not provided or the image data could not be processed
     422	The image could not be resized or is too large.
     */
-    public func postAccountUpdateProfileBannerWithImageData(_ imageData: Data, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postAccountUpdateProfileBanner(imageData: Data, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "account/update_profile_banner.json"
 
         var parameters = Dictionary<String, Any>()
@@ -485,7 +485,7 @@ public extension Swifter {
 
     Returns a map of the available size variations of the specified user's profile banner. If the user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string manipulation on the profile_banner_url returned in user objects as described in User Profile Images and Banners.
     */
-    public func getUsersProfileBannerWithUserID(_ userID: String, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getUsersProfileBanner(withUserId userID: String, success: ((response: JSON) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "users/profile_banner.json"
 
         self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in
@@ -502,7 +502,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postMutesUsersCreateForScreenName(_ screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersCreate(forScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -513,7 +513,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postMutesUsersCreateForUserID(_ userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersCreate(forUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -533,7 +533,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func postMutesUsersDestroyForScreenName(_ screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersDestroy(forScreenName screenName: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -544,7 +544,7 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postMutesUsersDestroyForUserID(_ userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func postMutesUsersDestroy(forUserId userID: String, success: ((user: Dictionary<String, JSON>?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -560,7 +560,7 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user has muted.
     */
-    public func getMutesUsersIDsWithCursor(_ cursor: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getMutesUsersIDs(cursor: String? = nil, success: ((ids: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -576,7 +576,7 @@ public extension Swifter {
     
     Returns an array of user objects the authenticating user has muted.
     */
-    public func getMutesUsersListWithCursor(_ cursor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
+    public func getMutesUsersList(cursor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/list.json"
         
         var parameters = Dictionary<String, Any>()


### PR DESCRIPTION
Thought I'd open a pull request to explain what I did.

In Swifter, wherever there is a method with both `screenName` OR `userId` options, Swifter offers 2 methods for users using either or. But sometimes people get confused with them, and it's not that great to have a lot of duplicated code.

So... I thought of a solution and implemented it today.

## UserTag

Now, there is a new `enum UserTag` that basically has 2 cases: `.id(String)` and `.screenName(String)`

How does this work exactly? Suppose you want to fetch a list of your favourited tweets. Previously, you had to choose between the two methods, and sometimes we make a mistake and mix the 2 up.
```swift
func getFavoritesList(withId userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {}

func getFavoritesList(withScreenName screenName: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {}
```

With the new implementation, there's just 1 method, and it works like this:
```swift
// method
func getFavoritesList(with userTag: UserTag, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: ((statuses: [JSON]?) -> Void)? = nil, failure: FailureHandler? = nil) {}

// usage (id)
swifter.getFavoritesList(with: .id(userId), ...)

// screenName
swifter.getFavoritesList(with: .screenName(userScreenName), ...)
```

By using an enum case under 1 method, the user will no longer be able to, at least easily, confuse the two. Plus, it reduces the size of Swifter as a lot of the similar methods have been merged into 1.

## ListTag

If anyone's checked out `SwifterLists.swift`, they'll notice that a lot of methods are duplicated due to conforming to all of the following: userId, screenName, slug, listId, userIds, screenNames

As a result, the file is one of the longest in Swifter, and causes confusion. `ListTag` works very similarly to `UserTag`, differing only in that in Twitter lists, using `slug` also requires the `owner_id` or the `owner_screen_name`

Here's how it works if you wanted to get a list's members:
```swift
// method
public func getListsMembers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: ((users: [JSON]?, previousCursor: String?, nextCursor: String?) -> Void)?, failure: FailureHandler?)  {}

// using listID
swifter.getListsMembers(for: .id(listId), ...)

// using slug and ownerId
swifter.getListsMembers(for: .slug(listSlug, .id(listOwnerID)), ...)

// using slug and ownerScreenName
swifter.getListsMembers(for: .slug(listSlug, .screenName(listOwnerScreenName)), ...)
```

## Conclusion
The implementation is now complete, and will be merged into the Swift 3 branch. 