### PR TITLE
Added a function with an extra parameter to use the "addtional_owners" in twitter's API

### DIFF
--- a/Swifter/SwifterTweets.swift
+++ b/Swifter/SwifterTweets.swift
@@ -186,6 +186,32 @@ public extension Swifter {
             success?(status: json.object)
             }, failure: failure)
     }
+	
+	/**
+	POST	media/upload
+	
+	Upload media (images) to Twitter for use in a Tweet or Twitter-hosted Card. For uploading videos or for chunked image uploads (useful for lower bandwidth connections), see our chunked POST media/upload endpoint.
+	The parameter "additionalOwners" is corresponding to the optional parameter "addtional_owners" in the twitter's document, which is a comma-separated list of user IDs to set as additional owners allowed to use the returned media_id in Tweets or Cards. Up to 100 additional owners may be specified.
+	
+	See:
+	
+	- https://dev.twitter.com/rest/reference/post/media/upload-init
+	*/
+	
+	public func postMedia(media: NSData, additionalOwners: [String], success: ((status: Dictionary<String, JSONValue>?) -> Void)? = nil, failure: FailureHandler? = nil) {
+		guard !additionalOwners.isEmpty else { return }
+		
+		let path: String = "media/upload.json"
+		var parameters = Dictionary<String, Any>()
+		parameters["media"] = media
+		parameters["additional_owners"] = additionalOwners.joinWithSeparator(",")
+		print(parameters["additional_owners"])
+		parameters[Swifter.DataParameters.dataKey] = "media"
+		
+		self.postJSONWithPath(path, baseURL: self.uploadURL, parameters: parameters, success: { json, _ in
+			success?(status: json.object)
+			}, failure: failure)
+	}
 
     /**
     POST	statuses/retweet/:id


### PR DESCRIPTION
The added parameter "additionalOwners" is corresponding to the optional
parameter "addtional_owners" in the twitter's document, which is a
comma-separated list of user IDs to set as additional owners allowed to
use the returned media_id in Tweets or Cards. Up to 100 additional
owners may be specified.

This parameter will be useful when someone wants to post a media tweet
by multiple twitter accounts at one time without having to uploading
the media for multiple times, which is a waste of networking.

I forked it just because I came across the problem to give some ownership of the media to reuse it. I spent hours to learn about the twitter's document and found it's really convenient to post a tweet with your awesome project, which is just lack of a parameter I need. 

Maybe few people have to post tweets through multiple accounts by sending once, and developers could extend the function by themselves easily. But the twitter has a too big document to read, and using your library would save much time to understand the whole process. I pulled the request to mean this.

Thank you for bringing such great tools again. xxx