### PR TITLE
Fix JSON.prettyPrint generates invalid JSON

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -184,7 +184,7 @@ public enum JSON : Equatable, CustomStringConvertible {
             return "\(number)"
             
         case .string(let string):
-            return "\"\(string)\""
+            return "\"\(string.replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\n", with: "\\n"))\""
             
         case .array(let array):
             return "[\n" + array.map { "\(nextIndent)\($0.prettyPrint(indent, level + 1))" }.joined(separator: ",\n") + "\n\(currentIndent)]"

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -184,7 +184,7 @@ public enum JSON : Equatable, CustomStringConvertible {
             return "\(number)"
             
         case .string(let string):
-            return "\"\(string.replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\n", with: "\\n"))\""
+            return "\"\(string.replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\r", with: "").replacingOccurrences(of: "\n", with: "\\n"))\""
             
         case .array(let array):
             return "[\n" + array.map { "\(nextIndent)\($0.prettyPrint(indent, level + 1))" }.joined(separator: ",\n") + "\n\(currentIndent)]"


### PR DESCRIPTION
I found the bug in JSON.prettyPrint method when including newline or quote in string

I fixed it, so please check it!

Regards,
