### PR TITLE
Fix leak in HTTPRequest.start()

### DIFF
--- a/Sources/SwifterHTTPRequest.swift
+++ b/Sources/SwifterHTTPRequest.swift
@@ -200,6 +200,10 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
             UIApplication.shared.isNetworkActivityIndicatorVisible = false
         #endif
 
+        defer {
+          session.finishTasksAndInvalidate()
+        }
+
         if let error = error {
             self.failureHandler?(error)
             return


### PR DESCRIPTION
`URLSession` holds a strong reference to its delegate, and only releases
that reference in a call to `finishTasksAndInvalidate()`. We need to call
it inside `HTTPRequest.urlSession(_:task:didCompleteWithError)`.

Before & After (in the Leaks instrument):
![screen shot 2017-05-16 at 12 57 57 pm](https://cloud.githubusercontent.com/assets/853032/26118283/559da788-3a37-11e7-84fb-f76d883b1e15.png)
