### PR TITLE
Media upload improvements

### DIFF
--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -132,12 +132,12 @@ public class Swifter {
                     }
                 } catch {
                     DispatchQueue.main.async {
-						if case 200 ... 299 = response.statusCode, data.count == 0 {
-							success?(JSON("{}"), response)
-						} else {
-							failure?(error)
-						}
-					}
+                        if case 200 ... 299 = response.statusCode, data.count == 0 {
+						    success?(JSON("{}"), response)
+                        } else {
+                            failure?(error)
+                        }
+                    }
                 }
             }
         }

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -132,8 +132,12 @@ public class Swifter {
                     }
                 } catch {
                     DispatchQueue.main.async {
-                        failure?(error)
-                    }
+						if case 200 ... 299 = response.statusCode, data.count == 0 {
+							success?(JSON("{}"), response)
+						} else {
+							failure?(error)
+						}
+					}
                 }
             }
         }

--- a/Sources/SwifterAccountsClient.swift
+++ b/Sources/SwifterAccountsClient.swift
@@ -65,17 +65,17 @@ internal class AccountsClient: SwifterClientProtocol {
 
         if let keyString = params[Swifter.DataParameters.dataKey] as? String {
             postDataKey = keyString
-            postData = params[postDataKey!] as? Data
+            postData = params[keyString] as? Data
             
             params.removeValue(forKey: Swifter.DataParameters.dataKey)
-            params.removeValue(forKey: postDataKey!)
+            params.removeValue(forKey: keyString)
         }
 
         var postDataFileName: String?
         if let fileName = params[Swifter.DataParameters.fileNameKey] as? String {
             postDataFileName = fileName
-            params.removeValue(forKey: fileName)
-        }
+			params.removeValue(forKey: Swifter.DataParameters.fileNameKey)
+       }
 
         let stringifiedParameters = params.stringifiedDictionary()
 

--- a/Sources/SwifterGIF.swift
+++ b/Sources/SwifterGIF.swift
@@ -1,0 +1,57 @@
+//
+//  SwifterGIF.swift
+//  Swifter
+//
+//  Created by Justin Greenfield on 6/30/17.
+//  Copyright © 2017 Matt Donnelly. All rights reserved.
+//
+
+import Foundation
+
+
+public enum GIFterError: Error {
+	case invalidData, invalidResponse
+}
+
+
+public extension Swifter {
+	
+	func tweetGIF(_ text: String, attachment: URL, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+		guard let data = try? Data(contentsOf: attachment) else { failure?(GIFterError.invalidData); return }
+		prepareUpload(data: data, success: { json, response in
+			if let media_id = json["media_id_string"].string {
+				self.uploadGIF(media_id, data: data, name: attachment.lastPathComponent, success: { json, response in
+					self.finalizeUpload(mediaId: media_id, success: { json, resoponse in
+						self.postTweet(status: text, media_ids: [media_id], success: success, failure: failure)
+					}, failure: failure)
+				}, failure: failure)
+			}
+			else {
+				failure?(GIFterError.invalidResponse)
+			}
+		}, failure: failure)
+	}
+	
+	private func prepareUpload(data: Data, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
+		let path = "media/upload.json"
+		let parameters : [String:Any] = ["command": "INIT", "total_bytes": data.count,
+		                  "media_type": "image/gif", "media_category": "tweet_gif"]
+		self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: success, failure: failure)
+	}
+	
+	private func finalizeUpload(mediaId: String, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
+		let path = "media/upload.json"
+		let parameters = ["command": "FINALIZE", "media_id" : mediaId]
+		self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: success, failure: failure)
+	}
+	
+	private func uploadGIF(_ mediaId: String, data: Data, name: String? = nil, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
+		let path = "media/upload.json"
+		let parameters : [String:Any] = ["command": "APPEND", "media_id": mediaId, "segment_index": "0",
+		                  Swifter.DataParameters.dataKey : "media",
+		                  Swifter.DataParameters.fileNameKey: name ?? "GIFter.gif",
+		                  "media": data]
+		self.jsonRequest(path: path, baseURL: .upload, method: .POST, parameters: parameters, success: success, failure: failure)
+	}
+	
+}

--- a/Sources/SwifterHTTPRequest.swift
+++ b/Sources/SwifterHTTPRequest.swift
@@ -111,13 +111,11 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
             for (key, value) in headers {
                 self.request!.setValue(value, forHTTPHeaderField: key)
             }
-            
-            let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.dataEncoding.rawValue))
-
+			
             let nonOAuthParameters = self.parameters.filter { key, _ in !key.hasPrefix("oauth_") }
 
             if !self.uploadData.isEmpty {
-                let boundary = "----------HTTPRequestBoUnDaRy"
+                let boundary = "--" + UUID().uuidString
 
                 let contentType = "multipart/form-data; boundary=\(boundary)"
                 self.request!.setValue(contentType, forHTTPHeaderField:"Content-Type")
@@ -140,15 +138,16 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
                 self.request!.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
                 self.request!.httpBody = body
             } else if !nonOAuthParameters.isEmpty {
+				let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.dataEncoding.rawValue))!
                 if self.HTTPMethod == .GET || self.HTTPMethod == .HEAD || self.HTTPMethod == .DELETE {
                     let queryString = nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
                     self.request!.url = self.url.append(queryString: queryString)
-                    self.request!.setValue("application/x-www-form-urlencoded; charset=\(String(describing: charset))", forHTTPHeaderField: "Content-Type")
+                    self.request!.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: "Content-Type")
                 } else {
                     var queryString = ""
                     if self.encodeParameters {
                         queryString = nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
-                        self.request!.setValue("application/x-www-form-urlencoded; charset=\(String(describing: charset))", forHTTPHeaderField: "Content-Type")
+                        self.request!.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: "Content-Type")
                     } else {
                         queryString = nonOAuthParameters.queryString
                     }
@@ -183,7 +182,7 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
 
     private class func mulipartContent(with boundary: String, data: Data, fileName: String?, parameterName: String,  mimeType mimeTypeOrNil: String?) -> Data {
         let mimeType = mimeTypeOrNil ?? "application/octet-stream"
-        let fileNameContentDisposition = fileName != nil ? "filename=\"\(String(describing: fileName))\"" : ""
+        let fileNameContentDisposition = fileName != nil ? "filename=\"\(fileName!)\"" : ""
         let contentDisposition = "Content-Disposition: form-data; name=\"\(parameterName)\"; \(fileNameContentDisposition)\r\n"
         
         var tempData = Data()
@@ -191,7 +190,6 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
         tempData.append(contentDisposition.data(using: .utf8)!)
         tempData.append("Content-Type: \(mimeType)\r\n\r\n".data(using: .utf8)!)
         tempData.append(data)
-        tempData.append("\r\n".data(using: .utf8)!)
         return tempData
     }
 

--- a/Sources/SwifterOAuthClient.swift
+++ b/Sources/SwifterOAuthClient.swift
@@ -76,10 +76,10 @@ internal class OAuthClient: SwifterClientProtocol  {
         if let key: Any = parameters[Swifter.DataParameters.dataKey] {
             if let keyString = key as? String {
                 postDataKey = keyString
-                postData = parameters[postDataKey!] as? Data
+                postData = parameters[keyString] as? Data
 
                 parameters.removeValue(forKey: Swifter.DataParameters.dataKey)
-                parameters.removeValue(forKey: postDataKey!)
+                parameters.removeValue(forKey: keyString)
             }
         }
 
@@ -87,8 +87,8 @@ internal class OAuthClient: SwifterClientProtocol  {
         if let fileName: Any = parameters[Swifter.DataParameters.fileNameKey] {
             if let fileNameString = fileName as? String {
                 postDataFileName = fileNameString
-                parameters.removeValue(forKey: fileNameString)
-            }
+				parameters.removeValue(forKey: Swifter.DataParameters.fileNameKey)
+           }
         }
 
         let request = HTTPRequest(url: url, method: .POST, parameters: parameters)

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		A1E207B31D4B86170093E498 /* Int++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E207B01D4B86170093E498 /* Int++.swift */; };
 		A1E207B41D4B86170093E498 /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E207B11D4B86170093E498 /* Data++.swift */; };
 		A1E207B51D4B86170093E498 /* Data++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E207B11D4B86170093E498 /* Data++.swift */; };
+		D0DCE3EE1F09C5E700B62429 /* SwifterGIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DCE3ED1F09C5E700B62429 /* SwifterGIF.swift */; };
+		D0DCE3EF1F09C5E700B62429 /* SwifterGIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DCE3ED1F09C5E700B62429 /* SwifterGIF.swift */; };
 		DC7D6B741ECA5294008586E3 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DC7D6B711ECA5294008586E3 /* Info.plist */; };
 		DC7D6B751ECA5294008586E3 /* String+SwifterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7D6B721ECA5294008586E3 /* String+SwifterTests.swift */; };
 		DC7D6B761ECA5294008586E3 /* SwifterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7D6B731ECA5294008586E3 /* SwifterTests.swift */; };
@@ -204,6 +206,7 @@
 		A1E207A81D4B85D90093E498 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		A1E207B01D4B86170093E498 /* Int++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int++.swift"; sourceTree = "<group>"; };
 		A1E207B11D4B86170093E498 /* Data++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data++.swift"; sourceTree = "<group>"; };
+		D0DCE3ED1F09C5E700B62429 /* SwifterGIF.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterGIF.swift; sourceTree = "<group>"; };
 		DC7D6B711ECA5294008586E3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC7D6B721ECA5294008586E3 /* String+SwifterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SwifterTests.swift"; sourceTree = "<group>"; };
 		DC7D6B731ECA5294008586E3 /* SwifterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterTests.swift; sourceTree = "<group>"; };
@@ -355,6 +358,7 @@
 				8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */,
 				8BA50EC61953828A00FB1829 /* SwifterAppOnlyClient.swift */,
 				8B116AF0194601970019A4DC /* SwifterHTTPRequest.swift */,
+				D0DCE3ED1F09C5E700B62429 /* SwifterGIF.swift */,
 				8B33CA3E19587C6D00739FCB /* JSON.swift */,
 				8B9F51591944A8E100894629 /* Extensions */,
 				8B5EFF10195F085B00B354F9 /* Supporting Files */,
@@ -634,6 +638,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0DCE3EE1F09C5E700B62429 /* SwifterGIF.swift in Sources */,
 				A17A694F1C78336200063DFD /* Operator++.swift in Sources */,
 				8BCF43291947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43261947CABA00E63301 /* SwifterSuggested.swift in Sources */,
@@ -677,6 +682,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0DCE3EF1F09C5E700B62429 /* SwifterGIF.swift in Sources */,
 				A17A69501C78336300063DFD /* Operator++.swift in Sources */,
 				8BCF432A1947CC7A00E63301 /* SwifterFavorites.swift in Sources */,
 				8BCF43271947CABA00E63301 /* SwifterSuggested.swift in Sources */,


### PR DESCRIPTION
These changes address the problems mentioned in #192.

Don't fail on an empty response with a 2xx status code, such as during a chunked media upload.

Fix the multipart form data issue causing chunked uploads to fail with a Twitter error on "FINALIZE".

Address a couple of String(describing:) issues with optional strings.

Fix a bug in OAuth and Accounts clients that fail to remove the fileNameKey from the parameters dictionary.

Added a simple tweetGIF method to post a tweet with an animated gif attached.
