### PR TITLE
Fix a number of typos in the public API

### DIFF
--- a/Sources/SwifterLists.swift
+++ b/Sources/SwifterLists.swift
@@ -144,7 +144,7 @@ public extension Swifter {
 
     Subscribes the authenticated user to the specified list.
     */
-    public func subsribeToList(for listTag: ListTag, owner ownerTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func subscribeToList(for listTag: ListTag, owner ownerTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Sources/SwifterTimelines.swift
+++ b/Sources/SwifterTimelines.swift
@@ -52,7 +52,7 @@ public extension Swifter {
 
     This method can only return up to 800 tweets.
     */
-    public func getMentionsTimlineTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler?) {
+    public func getMentionsTimelineTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler?) {
         self.getTimeline(at: "statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
     }
 

--- a/Sources/SwifterUsers.swift
+++ b/Sources/SwifterUsers.swift
@@ -79,7 +79,7 @@ public extension Swifter {
 
     Sets values that users are able to set under the "Account" tab of their settings page. Only the parameters specified will be updated.
     */
-    public func udpateUserProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateUserProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(name != nil || url != nil || location != nil || description != nil || includeEntities != nil || skipStatus != nil)
 
         let path = "account/update_profile.json"
@@ -100,7 +100,7 @@ public extension Swifter {
 
     Updates the authenticating user's profile background image. This method can also be used to enable or disable the profile background image. Although each parameter is marked as optional, at least one of image, tile or use must be provided when making this request.
     */
-    public func updateProfileBacground(using imageData: Data, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileBackground(using imageData: Data, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(title != nil || use != nil, "At least one of image, tile or use must be provided when making this request")
 
         let path = "account/update_profile_background_image.json"


### PR DESCRIPTION
Fixes typos in the names of a handful of functions across SwifterLists.swift, SwifterTimelines.swift and SwifterUsers.swift.