### PR TITLE
Split up excessively-long lines to improve readability

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -139,7 +139,8 @@ public enum JSON : Equatable, CustomStringConvertible {
     
     static func parse(jsonData: Data) throws -> JSON {
         do {
-            let object = try JSONSerialization.jsonObject(with: jsonData, options: .mutableContainers)
+            let object = try JSONSerialization.jsonObject(with: jsonData,
+                                                          options: .mutableContainers)
             return JSON(object)
         } catch {
             throw SwifterError(message: "\(error)", kind: .jsonParseError)
@@ -187,10 +188,14 @@ public enum JSON : Equatable, CustomStringConvertible {
             return "\"\(string)\""
             
         case .array(let array):
-            return "[\n" + array.map { "\(nextIndent)\($0.prettyPrint(indent, level + 1))" }.joined(separator: ",\n") + "\n\(currentIndent)]"
+            return "[\n" +
+                   array.map { "\(nextIndent)\($0.prettyPrint(indent, level + 1))" }
+                   .joined(separator: ",\n") + "\n\(currentIndent)]"
             
         case .object(let dict):
-            return "{\n" + dict.map { "\(nextIndent)\"\($0)\" : \($1.prettyPrint(indent, level + 1))"}.joined(separator: ",\n") + "\n\(currentIndent)}"
+            return "{\n" +
+                    dict.map { "\(nextIndent)\"\($0)\" : \($1.prettyPrint(indent, level + 1))"}
+                    .joined(separator: ",\n") + "\n\(currentIndent)}"
             
         case .null:
             return "null"

--- a/Sources/Operator++.swift
+++ b/Sources/Operator++.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 /// If `rhs` is not `nil`, assign it to `lhs`.
-infix operator ??= : AssignmentPrecedence // { associativity right precedence 90 assignment } // matches other assignment operators
+infix operator ??= : AssignmentPrecedence // { associativity right precedence 90 assignment }
+                                          // matches other assignment operators
 
 /// If `rhs` is not `nil`, assign it to `lhs`.
 func ??=<T>(lhs: inout T?, rhs: T?) {

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -31,7 +31,8 @@ import Accounts
 #endif
 
 extension Notification.Name {
-    static let SwifterCallbackNotification: Notification.Name = Notification.Name(rawValue: "SwifterCallbackNotificationName")
+    static let SwifterCallbackNotification =
+        Notification.Name(rawValue: "SwifterCallbackNotificationName")
 }
 
 // MARK: - Twitter URL
@@ -61,7 +62,8 @@ public class Swifter {
     // MARK: - Types
 
     public typealias SuccessHandler = (JSON) -> Void
-    public typealias CursorSuccessHandler = (JSON, _ previousCursor: String?, _ nextCursor: String?) -> Void
+    public typealias CursorSuccessHandler =
+        (JSON, _ previousCursor: String?, _ nextCursor: String?) -> Void
     public typealias JSONSuccessHandler = (JSON, _ response: HTTPURLResponse) -> Void
     public typealias FailureHandler = (_ error: Error) -> Void
 
@@ -86,8 +88,16 @@ public class Swifter {
             : OAuthClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
     }
 
-    public init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
-        self.client = OAuthClient(consumerKey: consumerKey, consumerSecret: consumerSecret , accessToken: oauthToken, accessTokenSecret: oauthTokenSecret)
+    public init(
+        consumerKey: String,
+        consumerSecret: String,
+        oauthToken: String,
+        oauthTokenSecret: String)
+    {
+        self.client = OAuthClient(consumerKey: consumerKey,
+                                  consumerSecret: consumerSecret,
+                                  accessToken: oauthToken,
+                                  accessTokenSecret: oauthTokenSecret)
     }
 
     #if os(macOS) || os(iOS)
@@ -103,8 +113,18 @@ public class Swifter {
     // MARK: - JSON Requests
     
     @discardableResult
-    internal func jsonRequest(path: String, baseURL: TwitterURL, method: HTTPMethodType, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) -> HTTPRequest {
-        let jsonDownloadProgressHandler: HTTPRequest.DownloadProgressHandler = { data, _, _, response in
+    internal func jsonRequest(
+        path: String,
+        baseURL: TwitterURL,
+        method: HTTPMethodType,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler? = nil,
+        downloadProgress: JSONSuccessHandler? = nil,
+        success: JSONSuccessHandler? = nil,
+        failure: HTTPRequest.FailureHandler? = nil) -> HTTPRequest
+    {
+        let jsonDownloadProgressHandler: HTTPRequest.DownloadProgressHandler = {
+            data, _, _, response in
 
             guard let _ = downloadProgress else { return }
             
@@ -113,7 +133,10 @@ public class Swifter {
                 let jsonChunks = jsonString!.components(separatedBy: "\r\n")
                 
                 for chunk in jsonChunks where !chunk.utf16.isEmpty {
-                    guard let chunkData = chunk.data(using: .utf8), let jsonResult = try? JSON.parse(jsonData: chunkData) else { continue }
+                    guard
+                        let chunkData = chunk.data(using: .utf8),
+                        let jsonResult = try? JSON.parse(jsonData: chunkData)
+                    else { continue }
                     downloadProgress?(jsonResult, response)
                 }
                 return
@@ -139,20 +162,63 @@ public class Swifter {
         }
 
         if method == .GET {
-            return self.client.get(path, baseURL: baseURL, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: jsonDownloadProgressHandler, success: jsonSuccessHandler, failure: failure)
+            return self.client.get(path,
+                                   baseURL: baseURL,
+                                   parameters: parameters,
+                                   uploadProgress: uploadProgress,
+                                   downloadProgress: jsonDownloadProgressHandler,
+                                   success: jsonSuccessHandler,
+                                   failure: failure)
         } else {
-            return self.client.post(path, baseURL: baseURL, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: jsonDownloadProgressHandler, success: jsonSuccessHandler, failure: failure)
+            return self.client.post(path,
+                                    baseURL: baseURL,
+                                    parameters: parameters,
+                                    uploadProgress: uploadProgress,
+                                    downloadProgress: jsonDownloadProgressHandler,
+                                    success: jsonSuccessHandler,
+                                    failure: failure)
         }
     }
 
     @discardableResult
-    internal func getJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
-        return self.jsonRequest(path: path, baseURL: baseURL, method: .GET, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, success: success, failure: failure)
+    internal func getJSON(
+        path: String, baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler? = nil,
+        downloadProgress: JSONSuccessHandler? = nil,
+        success: JSONSuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
+        return self.jsonRequest(path: path,
+                                baseURL: baseURL,
+                                method: .GET,
+                                parameters: parameters,
+                                uploadProgress: uploadProgress,
+                                downloadProgress: downloadProgress,
+                                success: success,
+                                failure: failure)
     }
 
     @discardableResult
-    internal func postJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
-        return self.jsonRequest(path: path, baseURL: baseURL, method: .POST, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, success: success, failure: failure)
+    internal func postJSON(
+        path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler? = nil,
+        downloadProgress: JSONSuccessHandler? = nil,
+        success: JSONSuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
+        return self.jsonRequest(path: path,
+                                baseURL: baseURL,
+                                method: .POST,
+                                parameters: parameters,
+                                uploadProgress: uploadProgress,
+                                downloadProgress: downloadProgress,
+                                success: success,
+                                failure: failure)
     }
     
 }

--- a/Sources/SwifterAccountsClient.swift
+++ b/Sources/SwifterAccountsClient.swift
@@ -37,12 +37,24 @@ internal class AccountsClient: SwifterClientProtocol {
         self.credential = Credential(account: account)
     }
 
-    func get(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func get(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)
 
         let stringifiedParameters = parameters.stringifiedDictionary()
         
-        let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter, requestMethod: .GET, url: url, parameters: stringifiedParameters)!
+        let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter,
+                                      requestMethod: .GET,
+                                      url: url,
+                                      parameters: stringifiedParameters)!
         socialRequest.account = self.credential!.account!
 
         let request = HTTPRequest(request: socialRequest.preparedURLRequest())
@@ -55,7 +67,16 @@ internal class AccountsClient: SwifterClientProtocol {
         return request
     }
 
-    func post(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func post(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)
 
         var params = parameters
@@ -79,12 +100,18 @@ internal class AccountsClient: SwifterClientProtocol {
 
         let stringifiedParameters = params.stringifiedDictionary()
 
-        let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter, requestMethod: .POST, url: url, parameters: stringifiedParameters)!
+        let socialRequest = SLRequest(forServiceType: SLServiceTypeTwitter,
+                                      requestMethod: .POST,
+                                      url: url,
+                                      parameters: stringifiedParameters)!
         socialRequest.account = self.credential!.account!
 
         if let data = postData {
             let fileName = postDataFileName ?? "media.jpg"
-            socialRequest.addMultipartData(data, withName: postDataKey!, type: "application/octet-stream", filename: fileName)
+            socialRequest.addMultipartData(data,
+                                           withName: postDataKey!,
+                                           type: "application/octet-stream",
+                                           filename: fileName)
         }
 
         let request = HTTPRequest(request: socialRequest.preparedURLRequest())

--- a/Sources/SwifterAppOnlyClient.swift
+++ b/Sources/SwifterAppOnlyClient.swift
@@ -39,7 +39,16 @@ internal class AppOnlyClient: SwifterClientProtocol  {
         self.consumerSecret = consumerSecret
     }
 
-    func get(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func get(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)
 
         let request = HTTPRequest(url: url!, method: .GET, parameters: parameters)
@@ -56,7 +65,16 @@ internal class AppOnlyClient: SwifterClientProtocol  {
         return request
     }
 
-    func post(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func post(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)
 
         let request = HTTPRequest(url: url!, method: .POST, parameters: parameters)
@@ -68,7 +86,9 @@ internal class AppOnlyClient: SwifterClientProtocol  {
         if let bearerToken = self.credential?.accessToken?.key {
             request.headers = ["Authorization": "Bearer \(bearerToken)"];
         } else {
-            let basicCredentials = AppOnlyClient.base64EncodedCredentials(withKey: self.consumerKey, secret: self.consumerSecret)
+            let basicCredentials =
+                AppOnlyClient.base64EncodedCredentials(withKey: self.consumerKey,
+                                                       secret: self.consumerSecret)
             request.headers = ["Authorization": "Basic \(basicCredentials)"];
             request.encodeParameters = true
         }

--- a/Sources/SwifterClientProtocol.swift
+++ b/Sources/SwifterClientProtocol.swift
@@ -30,9 +30,25 @@ public protocol SwifterClientProtocol {
     var credential: Credential? { get set }
 
     @discardableResult
-    func get(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest
+    func get(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
 
     @discardableResult
-    func post(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest
+    func post(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
 
 }

--- a/Sources/SwifterFavorites.swift
+++ b/Sources/SwifterFavorites.swift
@@ -32,9 +32,16 @@ public extension Swifter {
 
     Returns the 20 most recent Tweets favorited by the authenticating or specified user.
 
-    If you do not provide either a user_id or screen_name to this method, it will assume you are requesting on behalf of the authenticating user. Specify one or the other for best results.
+    If you do not provide either a user_id or screen_name to this method, it will assume you are
+     requesting on behalf of the authenticating user. Specify one or the other for best results.
     */
-    public func getRecentlyFavouritedTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRecentlyFavouritedTweets(
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -42,10 +49,21 @@ public extension Swifter {
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
-    public func getRecentlyFavouritedTweets(for userTag: UserTag, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRecentlyFavouritedTweets(
+        for userTag: UserTag,
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "favorites/list.json"
         
         var parameters = Dictionary<String, Any>()
@@ -54,41 +72,69 @@ public extension Swifter {
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     POST	favorites/destroy
 
-    Un-favorites the status specified in the ID parameter as the authenticating user. Returns the un-favorited status in the requested format when successful.
+    Un-favorites the status specified in the ID parameter as the authenticating user. Returns the
+     un-favorited status in the requested format when successful.
 
-    This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
+    This process invoked by this method is asynchronous. The immediately returned status may not
+     indicate the resultant favorited status of the tweet. A 200 OK response from this method will
+     indicate whether the intended action was successful or not.
     */
-    public func unfavouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unfavouriteTweet(
+        forID id: String,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "favorites/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	favorites/create
 
-    Favorites the status specified in the ID parameter as the authenticating user. Returns the favorite status when successful.
+    Favorites the status specified in the ID parameter as the authenticating user. Returns the
+     favorite status when successful.
 
-    This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
+    This process invoked by this method is asynchronous. The immediately returned status may not
+     indicate the resultant favorited status of the tweet. A 200 OK response from this method will
+     indicate whether the intended action was successful or not.
     */
-    public func favouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) {
+    public func favouriteTweet(
+        forID id: String,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: HTTPRequest.FailureHandler? = nil)
+    {
         let path = "favorites/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
 }

--- a/Sources/SwifterFollowers.swift
+++ b/Sources/SwifterFollowers.swift
@@ -30,28 +30,51 @@ public extension Swifter {
     /**
     GET    friendships/no_retweets/ids
 
-    Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from. Use POST friendships/update to set the "no retweets" status for a given user account on behalf of the current user.
+    Returns a collection of user_ids that the currently authenticated user does not want to receive
+     retweets from. Use POST friendships/update to set the "no retweets" status for a given user
+     account on behalf of the current user.
     */
-    public func listOfNoRetweetsFriends(stringifyIDs: Bool = true, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func listOfNoRetweetsFriends(
+        stringifyIDs: Bool = true,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/no_retweets/ids.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["stringify_ids"] = stringifyIDs
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    friends/ids
     Returns Users (*: user IDs for followees)
 
-    Returns a cursored collection of user IDs for every user the specified user is following (otherwise known as their "friends").
+    Returns a cursored collection of user IDs for every user the specified user is following
+     (otherwise known as their "friends").
 
-    At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 5,000 user IDs and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
+    At this time, results are ordered with the most recent following first — however, this ordering
+     is subject to unannounced change and eventual consistency issues. Results are given in groups
+     of 5,000 user IDs and multiple "pages" of results can be navigated through using the
+     next_cursor value in subsequent requests. See Using cursors to navigate collections for more
+     information.
 
-    This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
+    This method is especially powerful when used in conjunction with GET users/lookup, a method that
+     allows you to convert user IDs into full user objects in bulk.
     */
-    public func getUserFollowingIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowingIDs(
+        for userTag: UserTag,
+        cursor: String? = nil,
+        stringifyIDs: Bool? = nil,
+        count: Int? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -60,9 +83,17 @@ public extension Swifter {
         parameters["stringify_ids"] ??= stringifyIDs
         parameters["count"] ??= count
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
@@ -70,11 +101,23 @@ public extension Swifter {
     
     Returns a cursored collection of user IDs for every user following the specified user.
     
-    At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 5,000 user IDs and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
+    At this time, results are ordered with the most recent following first — however, this ordering
+     is subject to unannounced change and eventual consistency issues. Results are given in groups
+     of 5,000 user IDs and multiple "pages" of results can be navigated through using the
+     next_cursor value in subsequent requests. See Using cursors to navigate collections for more
+     information.
     
-    This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
+    This method is especially powerful when used in conjunction with GET users/lookup, a method that
+     allows you to convert user IDs into full user objects in bulk.
     */
-    public func getUserFollowersIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowersIDs(
+        for userTag: UserTag,
+        cursor: String? = nil,
+        stringifyIDs: Bool? = nil,
+        count: Int? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -83,43 +126,79 @@ public extension Swifter {
         parameters["stringify_ids"] ??= stringifyIDs
         parameters["count"] ??= count
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
     GET    friendships/incoming
     
-    Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
+    Returns a collection of numeric IDs for every user who has a pending request to follow the
+     authenticating user.
     */
-    public func getIncomingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getIncomingPendingFollowRequests(
+        cursor: String? = nil,
+        stringifyIDs: String? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/incoming.json"
         
         var parameters = Dictionary<String, Any>()
         parameters["cursor"] ??= cursor
         parameters["stringify_ids"] ??= stringifyIDs
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
     GET    friendships/outgoing
     
-    Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
+    Returns a collection of numeric IDs for every protected user for whom the authenticating user
+     has a pending follow request.
     */
-    public func getOutgoingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getOutgoingPendingFollowRequests(
+        cursor: String? = nil,
+        stringifyIDs: String? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/outgoing.json"
         
         var parameters = Dictionary<String, Any>()
         parameters["cursor"] ??= cursor
         parameters["stringify_ids"] ??= stringifyIDs
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
@@ -127,20 +206,30 @@ public extension Swifter {
 
     Allows the authenticating users to follow the user specified in the ID parameter.
 
-    Returns the befriended user in the requested format when successful. Returns a string describing the failure condition when unsuccessful. If you are already friends with the user a HTTP 403 may be returned, though for performance reasons you may get a 200 OK message even if the friendship already exists.
+    Returns the befriended user in the requested format when successful. Returns a string describing
+     the failure condition when unsuccessful. If you are already friends with the user a HTTP 403
+     may be returned, though for performance reasons you may get a 200 OK message even if the
+     friendship already exists.
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func followUser(for userTag: UserTag, follow: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func followUser(
+        for userTag: UserTag,
+        follow: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["follow"] ??= follow
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -148,19 +237,26 @@ public extension Swifter {
 
     Allows the authenticating user to unfollow the user specified in the ID parameter.
 
-    Returns the unfollowed user in the requested format when successful. Returns a string describing the failure condition when unsuccessful.
+    Returns the unfollowed user in the requested format when successful. Returns a string describing
+     the failure condition when unsuccessful.
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func unfollowUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unfollowUser(
+        for userTag: UserTag,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -168,7 +264,13 @@ public extension Swifter {
 
     Allows one to enable or disable retweets and device notifications from the specified user.
     */
-    public func updateFriendship(with userTag: UserTag, device: Bool? = nil, retweets: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateFriendship(
+        with userTag: UserTag,
+        device: Bool? = nil,
+        retweets: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -176,9 +278,11 @@ public extension Swifter {
         parameters["device"] ??= device
         parameters["retweets"] ??= retweets
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -186,7 +290,12 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func showFriendship(between sourceTag: UserTag, and targetTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showFriendship(
+        between sourceTag: UserTag,
+        and targetTag: UserTag,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -200,19 +309,33 @@ public extension Swifter {
         case .screenName:   parameters["target_screen_name"] = targetTag.value
         }
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    friends/list
 
-    Returns a cursored collection of user objects for every user the specified user is following (otherwise known as their "friends").
+    Returns a cursored collection of user objects for every user the specified user is following
+     (otherwise known as their "friends").
 
-    At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
+    At this time, results are ordered with the most recent following first — however, this ordering
+     is subject to unannounced change and eventual consistency issues. Results are given in groups
+     of 20 users and multiple "pages" of results can be navigated through using the next_cursor
+     value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getUserFollowing(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowing(
+        for userTag: UserTag,
+        cursor: String? = nil,
+        count: Int? = nil,
+        skipStatus: Bool? = nil,
+        includeUserEntities: Bool? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -222,9 +345,18 @@ public extension Swifter {
         parameters["skip_status"] ??= skipStatus
         parameters["include_user_entities"] ??= includeUserEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
@@ -232,9 +364,20 @@ public extension Swifter {
 
     Returns a cursored collection of user objects for users following the specified user.
 
-    At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
+    At this time, results are ordered with the most recent following first — however, this ordering
+     is subject to unannounced change and eventual consistency issues. Results are given in groups
+     of 20 users and multiple "pages" of results can be navigated through using the next_cursor
+     value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getUserFollowers(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowers(
+        for userTag: UserTag,
+        cursor: String? = nil,
+        count: Int? = nil,
+        skipStatus: Bool? = nil,
+        includeUserEntities: Bool? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -244,25 +387,41 @@ public extension Swifter {
         parameters["skip_status"] ??= skipStatus
         parameters["include_user_entities"] ??= includeUserEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
     GET    friendships/lookup
 
-    Returns the relationships of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by, none.
+    Returns the relationships of the authenticating user to the comma-separated list of up to 100
+     screen_names or user_ids provided. Values for connections can be: following,
+     following_requested, followed_by, none.
     */
-    public func lookupFriendship(with usersTag: UsersTag, success: SuccessHandler? = nil, failure: FailureHandler?) {
+    public func lookupFriendship(
+        with usersTag: UsersTag,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler?) {
         let path = "friendships/lookup.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[usersTag.key] = usersTag.value
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterHTTPRequest.swift
+++ b/Sources/SwifterHTTPRequest.swift
@@ -46,8 +46,11 @@ public enum HTTPMethodType: String {
 
 public class HTTPRequest: NSObject, URLSessionDataDelegate {
 
-    public typealias UploadProgressHandler = (_ bytesWritten: Int, _ totalBytesWritten: Int, _ totalBytesExpectedToWrite: Int) -> Void
-    public typealias DownloadProgressHandler = (Data, _ totalBytesReceived: Int, _ totalBytesExpectedToReceive: Int, HTTPURLResponse) -> Void
+    public typealias UploadProgressHandler =
+        (_ bytesWritten: Int, _ totalBytesWritten: Int, _ totalBytesExpectedToWrite: Int) -> Void
+    public typealias DownloadProgressHandler =
+        (Data, _ totalBytesReceived: Int, _ totalBytesExpectedToReceive: Int, HTTPURLResponse)
+        -> Void
     public typealias SuccessHandler = (Data, HTTPURLResponse) -> Void
     public typealias FailureHandler = (Error) -> Void
 
@@ -84,7 +87,11 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
     var successHandler: SuccessHandler?
     var failureHandler: FailureHandler?
 
-    public init(url: URL, method: HTTPMethodType = .GET, parameters: Dictionary<String, Any> = [:]) {
+    public init(
+        url: URL,
+        method: HTTPMethodType = .GET,
+        parameters: Dictionary<String, Any> = [:])
+    {
         self.url = url
         self.HTTPMethod = method
         self.parameters = parameters
@@ -100,8 +107,6 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
     }
 
     public func start() {
-        
-        
         if request == nil {
             self.request = URLRequest(url: self.url)
             self.request!.httpMethod = self.HTTPMethod.rawValue
@@ -112,7 +117,8 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
                 self.request!.setValue(value, forHTTPHeaderField: key)
             }
             
-            let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.dataEncoding.rawValue))
+            let charset = CFStringConvertEncodingToIANACharSetName(
+                            CFStringConvertNSStringEncodingToEncoding(self.dataEncoding.rawValue))
 
             let nonOAuthParameters = self.parameters.filter { key, _ in !key.hasPrefix("oauth_") }
 
@@ -125,13 +131,20 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
                 var body = Data()
 
                 for dataUpload: DataUpload in self.uploadData {
-                    let multipartData = HTTPRequest.mulipartContent(with: boundary, data: dataUpload.data, fileName: dataUpload.fileName, parameterName: dataUpload.parameterName, mimeType: dataUpload.mimeType)
+                    let multipartData =
+                            HTTPRequest.mulipartContent(with: boundary,
+                                                        data: dataUpload.data,
+                                                        fileName: dataUpload.fileName,
+                                                        parameterName: dataUpload.parameterName,
+                                                        mimeType: dataUpload.mimeType)
                     body.append(multipartData)
                 }
 
                 for (key, value): (String, Any) in nonOAuthParameters {
                     body.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
-                    body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+                    body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n"
+                                    .data(using: .utf8)!
+                    )
                     body.append("\(value)".data(using: .utf8)!)
                 }
 
@@ -141,14 +154,21 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
                 self.request!.httpBody = body
             } else if !nonOAuthParameters.isEmpty {
                 if self.HTTPMethod == .GET || self.HTTPMethod == .HEAD || self.HTTPMethod == .DELETE {
-                    let queryString = nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
+                    let queryString =
+                        nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
                     self.request!.url = self.url.append(queryString: queryString)
-                    self.request!.setValue("application/x-www-form-urlencoded; charset=\(String(describing: charset))", forHTTPHeaderField: "Content-Type")
+                    self.request!.setValue(
+                            "application/x-www-form-urlencoded; charset=\(String(describing: charset))",
+                            forHTTPHeaderField: "Content-Type")
                 } else {
                     var queryString = ""
                     if self.encodeParameters {
-                        queryString = nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
-                        self.request!.setValue("application/x-www-form-urlencoded; charset=\(String(describing: charset))", forHTTPHeaderField: "Content-Type")
+                        queryString =
+                            nonOAuthParameters.urlEncodedQueryString(using: self.dataEncoding)
+                        self.request!
+                            .setValue(
+                                "application/x-www-form-urlencoded; charset=\(String(describing: charset))",
+                                forHTTPHeaderField: "Content-Type")
                     } else {
                         queryString = nonOAuthParameters.queryString
                     }
@@ -176,15 +196,30 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
         self.dataTask.cancel()
     }
 
-    public func add(multipartData data: Data, parameterName: String, mimeType: String?, fileName: String?) -> Void {
+    public func add(
+        multipartData data: Data,
+        parameterName: String,
+        mimeType: String?,
+        fileName: String?)
+        -> Void
+    {
         let dataUpload = DataUpload(data: data, parameterName: parameterName, mimeType: mimeType, fileName: fileName)
         self.uploadData.append(dataUpload)
     }
 
-    private class func mulipartContent(with boundary: String, data: Data, fileName: String?, parameterName: String,  mimeType mimeTypeOrNil: String?) -> Data {
+    private class func mulipartContent(
+        with boundary: String,
+        data: Data,
+        fileName: String?,
+        parameterName: String,
+        mimeType mimeTypeOrNil: String?)
+        -> Data
+    {
         let mimeType = mimeTypeOrNil ?? "application/octet-stream"
-        let fileNameContentDisposition = fileName != nil ? "filename=\"\(String(describing: fileName))\"" : ""
-        let contentDisposition = "Content-Disposition: form-data; name=\"\(parameterName)\"; \(fileNameContentDisposition)\r\n"
+        let fileNameContentDisposition =
+            fileName != nil ? "filename=\"\(String(describing: fileName))\"" : ""
+        let contentDisposition =
+            "Content-Disposition: form-data; name=\"\(parameterName)\"; \(fileNameContentDisposition)\r\n"
         
         var tempData = Data()
         tempData.append("--\(boundary)\r\n".data(using: .utf8)!)
@@ -197,7 +232,11 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
 
     // MARK: - URLSessionDataDelegate
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?)
+    {
         #if os(iOS)
             UIApplication.shared.isNetworkActivityIndicatorVisible = false
         #endif
@@ -217,29 +256,52 @@ public class HTTPRequest: NSObject, URLSessionDataDelegate {
         }
         let responseString = String(data: responseData, encoding: dataEncoding)!
         let errorCode = HTTPRequest.responseErrorCode(for: responseData) ?? 0
-        let localizedDescription = HTTPRequest.description(for: response.statusCode, response: responseString)
+        let localizedDescription = HTTPRequest.description(for: response.statusCode,
+                                                           response: responseString)
         
-        let error = SwifterError(message: localizedDescription, kind: .urlResponseError(status: response.statusCode, headers: response.allHeaderFields, errorCode: errorCode))
+        let error = SwifterError(message: localizedDescription,
+                                 kind: .urlResponseError(status: response.statusCode,
+                                                         headers: response.allHeaderFields,
+                                                         errorCode: errorCode))
         self.failureHandler?(error)
     }
     
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    public func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data)
+    {
         self.responseData.append(data)
         
         let expectedContentLength = Int(self.response!.expectedContentLength)
         let totalBytesReceived = self.responseData.count
         
         guard !data.isEmpty else { return }
-        self.downloadProgressHandler?(data, totalBytesReceived, expectedContentLength, self.response)
+        self.downloadProgressHandler?(data,
+                                      totalBytesReceived,
+                                      expectedContentLength,
+                                      self.response)
     }
     
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    public func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition)
+        -> Void)
+    {
         self.response = response as? HTTPURLResponse
         self.responseData.count = 0
         completionHandler(.allow)
     }
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didSendBodyData bytesSent: Int64,
+        totalBytesSent: Int64,
+        totalBytesExpectedToSend: Int64)
+    {
         self.uploadProgressHandler?(Int(bytesSent), Int(totalBytesSent), Int(totalBytesExpectedToSend))
     }
     

--- a/Sources/SwifterHelp.swift
+++ b/Sources/SwifterHelp.swift
@@ -30,9 +30,11 @@ public extension Swifter {
     /**
     GET    help/configuration
 
-    Returns the current configuration used by Twitter including twitter.com slugs which are not usernames, maximum photo resolutions, and t.co URL lengths.
+    Returns the current configuration used by Twitter including twitter.com slugs which are not
+     usernames, maximum photo resolutions, and t.co URL lengths.
 
-    It is recommended applications request this endpoint when they are loaded, but no more than once a day.
+    It is recommended applications request this endpoint when they are loaded, but no more than once
+     a day.
     */
     public func getHelpConfiguration(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/configuration.json"
@@ -43,7 +45,8 @@ public extension Swifter {
     /**
     GET    help/languages
 
-    Returns the list of languages supported by Twitter along with their ISO 639-1 code. The ISO 639-1 code is the two letter value to use if you include lang with any of your requests.
+    Returns the list of languages supported by Twitter along with their ISO 639-1 code. The
+     ISO 639-1 code is the two letter value to use if you include lang with any of your requests.
     */
     public func getHelpLanguages(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/languages.json"
@@ -59,18 +62,30 @@ public extension Swifter {
     public func getHelpPrivacy(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/privacy.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["privacy"]) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json["privacy"]) },
+                     failure: failure)
     }
 
     /**
     GET    help/tos
 
-    Returns the Twitter Terms of Service in the requested format. These are not the same as the Developer Rules of the Road.
+    Returns the Twitter Terms of Service in the requested format. These are not the same as the
+     Developer Rules of the Road.
     */
-    public func getHelpTermsOfService(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getHelpTermsOfService(
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "help/tos.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["tos"]) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json["tos"]) },
+                     failure: failure)
     }
 
     /**
@@ -78,23 +93,39 @@ public extension Swifter {
 
     Returns the current rate limits for methods belonging to the specified resource families.
 
-    Each 1.1 API resource belongs to a "resource family" which is indicated in its method documentation. You can typically determine a method's resource family from the first component of the path after the resource version.
+    Each 1.1 API resource belongs to a "resource family" which is indicated in its method
+     documentation. You can typically determine a method's resource family from the first component
+     of the path after the resource version.
 
-    This method responds with a map of methods belonging to the families specified by the resources parameter, the current remaining uses for each of those resources within the current rate limiting window, and its expiration time in epoch time. It also includes a rate_limit_context field that indicates the current access token or application-only authentication context.
+    This method responds with a map of methods belonging to the families specified by the resources
+     parameter, the current remaining uses for each of those resources within the current rate
+     limiting window, and its expiration time in epoch time. It also includes a rate_limit_context
+     field that indicates the current access token or application-only authentication context.
 
-    You may also issue requests to this method without any parameters to receive a map of all rate limited GET methods. If your application only uses a few of methods, please explicitly provide a resources parameter with the specified resource families you work with.
+    You may also issue requests to this method without any parameters to receive a map of all rate
+     limited GET methods. If your application only uses a few of methods, please explicitly provide
+     a resources parameter with the specified resource families you work with.
 
-    When using app-only auth, this method's response indicates the app-only auth rate limiting context.
+    When using app-only auth, this method's response indicates the app-only auth rate limiting
+     context.
 
     Read more about REST API Rate Limiting in v1.1 and review the limits.
     */
-    public func getRateLimits(for resources: [String], success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRateLimits(
+        for resources: [String],
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "application/rate_limit_status.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["resources"] = resources.joined(separator: ",")
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterLists.swift
+++ b/Sources/SwifterLists.swift
@@ -30,41 +30,73 @@ public extension Swifter {
     /**
     GET    lists/list
 
-    Returns all lists the authenticating or specified user subscribes to, including their own. The user is specified using the user_id or screen_name parameters. If no user is given, the authenticating user is used.
+    Returns all lists the authenticating or specified user subscribes to, including their own. The
+     user is specified using the user_id or screen_name parameters. If no user is given, the
+     authenticating user is used.
 
-    This method used to be GET lists in version 1.0 of the API and has been renamed for consistency with other call.
+    This method used to be GET lists in version 1.0 of the API and has been renamed for consistency
+     with other call.
 
-    A maximum of 100 results will be returned by this call. Subscribed lists are returned first, followed by owned lists. This means that if a user subscribes to 90 lists and owns 20 lists, this method returns 90 subscriptions and 10 owned lists. The reverse method returns owned lists first, so with reverse=true, 20 owned lists and 80 subscriptions would be returned. If your goal is to obtain every list a user owns or subscribes to, use GET lists/ownerships and/or GET lists/subscriptions instead.
+    A maximum of 100 results will be returned by this call. Subscribed lists are returned first,
+     followed by owned lists. This means that if a user subscribes to 90 lists and owns 20 lists,
+     this method returns 90 subscriptions and 10 owned lists. The reverse method returns owned lists
+     first, so with reverse=true, 20 owned lists and 80 subscriptions would be returned. If your
+     goal is to obtain every list a user owns or subscribes to, use GET lists/ownerships and/or GET
+     lists/subscriptions instead.
     */
-    public func getSubscribedLists(reverse: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedLists(
+        reverse: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["reverse"] ??= reverse
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
-    public func getSubscribedLists(for userTag: UserTag, reverse: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedLists(
+        for userTag: UserTag,
+        reverse: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["reverse"] ??= reverse
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET	lists/statuses
 
-    Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great way to embed list timelines on your website.
+    Returns a timeline of tweets authored by members of the specified list. Retweets are included by
+     default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great
+     way to embed list timelines on your website.
     */
-    public func listTweets(for listTag: ListTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func listTweets(
+        for listTag: ListTag,
+        sinceID: String?,
+        maxID: String?,
+        count: Int?, 
+        includeEntities: Bool?,
+        includeRTs: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -78,15 +110,25 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["include_rts"] ??= includeRTs
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters, 
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     POST	lists/members/destroy
 
-    Removes the specified member from the list. The authenticated user must be the list's owner to remove members from the list.
+    Removes the specified member from the list. The authenticated user must be the list's owner to
+     remove members from the list.
     */
-    public func removeMemberFromList(for listTag: ListTag, user userTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func removeMemberFromList(
+        for listTag: ListTag,
+        user userTag: UserTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -96,15 +138,26 @@ public extension Swifter {
         }
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET    lists/memberships
 
-    Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
+    Returns the lists the specified user has been added to. If user_id or screen_name are not
+     provided the memberships for the authenticating user are returned.
     */
-    public func getListMemberships(for userTag: UserTag, cursor: String?, filterToOwnedLists: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListMemberships(
+        for userTag: UserTag,
+        cursor: String?,
+        filterToOwnedLists: Bool?,
+        success: CursorSuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, Any>()
@@ -112,17 +165,33 @@ public extension Swifter {
         parameters["cursor"] ??= cursor
         parameters["filter_to_owned_lists"] ??= filterToOwnedLists
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["lists"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
     GET	lists/subscribers
 
-    Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
+    Returns the subscribers of the specified list. Private list subscribers will only be shown if
+     the authenticated user owns the specified list.
     */
-    public func getListSubscribers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListSubscribers(
+        for listTag: ListTag,
+        cursor: String?,
+        includeEntities: Bool?,
+        skipStatus: Bool?,
+        success: CursorSuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -134,9 +203,17 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
@@ -144,7 +221,12 @@ public extension Swifter {
 
     Subscribes the authenticated user to the specified list.
     */
-    public func subscribeToList(for listTag: ListTag, owner ownerTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func subscribeToList(
+        for listTag: ListTag,
+        owner ownerTag: UserTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -153,15 +235,27 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET	lists/subscribers/show
 
-    Check if the specified user is a subscriber of the specified list. Returns the user if they are subscriber.
+    Check if the specified user is a subscriber of the specified list. Returns the user if they are
+     subscriber.
     */
-    public func checkListSubcription(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func checkListSubcription(
+        of userTag: UserTag,
+        for listTag: ListTag,
+        includeEntities: Bool?,
+        skipStatus: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -173,7 +267,11 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -181,7 +279,11 @@ public extension Swifter {
 
     Unsubscribes the authenticated user from the specified list.
     */
-    public func unsubscribeFromList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func unsubscribeFromList(
+        for listTag: ListTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -190,17 +292,31 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	lists/members/create_all
 
-    Adds multiple members to a list, by specifying a comma-separated list of member ids or screen names. The authenticated user must own the list to be able to add members to it. Note that lists can't have more than 5,000 members, and you are limited to adding up to 100 members to a list at a time with this method.
+    Adds multiple members to a list, by specifying a comma-separated list of member ids or screen
+     names. The authenticated user must own the list to be able to add members to it. Note that
+     lists can't have more than 5,000 members, and you are limited to adding up to 100 members to a
+     list at a time with this method.
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func subscribeUsersToList(for listTag: ListTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func subscribeUsersToList(
+        for listTag: ListTag,
+        users usersTag: UsersTag,
+        includeEntities: Bool?,
+        skipStatus: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -213,7 +329,11 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -221,7 +341,14 @@ public extension Swifter {
 
     Check if the specified user is a member of the specified list.
     */
-    public func checkListMembership(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func checkListMembership(
+        of userTag: UserTag,
+        for listTag: ListTag,
+        includeEntities: Bool?,
+        skipStatus: Bool?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -233,16 +360,28 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    lists/members
 
-    Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
+    Returns the members of the specified list. Private list members will only be shown if the
+     authenticated user owns the specified list.
     */
 
-    public func getListMembers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListMembers(
+        for listTag: ListTag,
+        cursor: String?,
+        includeEntities: Bool?,
+        skipStatus: Bool?,
+        success: CursorSuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -254,17 +393,31 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
     POST	lists/members/create
 
-    Add a member to a list. The authenticated user must own the list to be able to add members to it. Note that lists cannot have more than 5,000 members.
+    Add a member to a list. The authenticated user must own the list to be able to add members to
+     it. Note that lists cannot have more than 5,000 members.
     */
-    public func addListMember(_ userTag: UserTag, for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func addListMember(
+        _ userTag: UserTag,
+        for listTag: ListTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -274,7 +427,11 @@ public extension Swifter {
         }
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -282,7 +439,11 @@ public extension Swifter {
 
     Deletes the specified list. The authenticated user must own the list to be able to destroy it.
     */
-    public func deleteList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func deleteList(
+        for listTag: ListTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -291,7 +452,11 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -299,7 +464,14 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func updateList(for listTag: ListTag, name: String?, isPublic: Bool = true, description: String?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func updateList(
+        for listTag: ListTag,
+        name: String?,
+        isPublic: Bool = true,
+        description: String?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -311,15 +483,26 @@ public extension Swifter {
         parameters["mode"] = isPublic ? "public" : "private"
         parameters["description"] ??= description
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
     /**
     POST	lists/create
 
-    Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
+    Creates a new list for the authenticated user. Note that you can't create more than 20 lists per
+     account.
     */
-    public func createList(named name: String, asPublicList: Bool = true, description: String?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func createList(
+        named name: String,
+        asPublicList: Bool = true,
+        description: String?,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -327,15 +510,24 @@ public extension Swifter {
         parameters["mode"] = asPublicList ? "public" : "private"
         parameters["description"] ??= description
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET	lists/show
 
-    Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
+    Returns the specified list. Private lists will only be shown if the authenticated user owns the
+     specified list.
     */
-    public func showList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func showList(
+        for listTag: ListTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -344,17 +536,26 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET	lists/subscriptions
 
-    Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default. Does not include the user's own lists.
+    Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by
+     default. Does not include the user's own lists.
     */
-    public func getSubscribedList(of userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedList(
+        of userTag: UserTag,
+        count: String?,
+        cursor: String?,
+        success: CursorSuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/subscriptions.json"
 
         var parameters = Dictionary<String, Any>()
@@ -362,19 +563,37 @@ public extension Swifter {
         parameters["count"] ??= count
         parameters["cursor"] ??= cursor
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["lists"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
     POST	lists/members/destroy_all
 
-    Removes multiple members from a list, by specifying a comma-separated list of member ids or screen names. The authenticated user must own the list to be able to remove members from it. Note that lists can't have more than 500 members, and you are limited to removing up to 100 members to a list at a time with this method.
+    Removes multiple members from a list, by specifying a comma-separated list of member ids or
+     screen names. The authenticated user must own the list to be able to remove members from it.
+     Note that lists can't have more than 500 members, and you are limited to removing up to 100
+     members to a list at a time with this method.
 
-    Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
+    Please note that there can be issues with lists that rapidly remove and add memberships. Take
+     care when using these methods such that you are not too rapidly switching between removals and
+     adds on the same list.
     */
-    public func removeListMembers(_ usersTag: UsersTag, for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func removeListMembers(
+        _ usersTag: UsersTag,
+        for listTag: ListTag,
+        success: SuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -384,15 +603,26 @@ public extension Swifter {
         }
         parameters[usersTag.key] = usersTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
     /**
     GET    lists/ownerships
     
-    Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
+    Returns the lists owned by the specified Twitter user. Private lists will only be shown if the
+     authenticated user is also the owner of the lists.
     */
-    public func getOwnedLists(for userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getOwnedLists(
+        for userTag: UserTag,
+        count: String?,
+        cursor: String?,
+        success: CursorSuccessHandler?,
+        failure: FailureHandler?)
+    {
         let path = "lists/ownerships.json"
         
         var parameters = Dictionary<String, Any>()
@@ -400,21 +630,25 @@ public extension Swifter {
         parameters["count"] ??= count
         parameters["cursor"] ??= cursor
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
-            success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
+            },
+            failure: failure)
         
     }
     
 }
 
 private extension UserTag {
-    
     var ownerKey: String {
         switch self {
         case .id:           return "owner_id"
         case .screenName:   return "owner_screen_name"
         }
     }
-    
 }

--- a/Sources/SwifterMessages.swift
+++ b/Sources/SwifterMessages.swift
@@ -30,9 +30,18 @@ public extension Swifter {
     /**
     GET	direct_messages
 
-    Returns the 20 most recent direct messages sent to the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 incoming DMs.
+    Returns the 20 most recent direct messages sent to the authenticating user. Includes detailed
+     information about the sender and recipient user. You can request up to 200 direct messages per
+     call, up to a maximum of 800 incoming DMs.
     */
-    public func getDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getDirectMessages(
+        since sinceID: String? = nil,
+        maxID: String? = nil, count: Int? = nil,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "direct_messages.json"
 
         var parameters = Dictionary<String, Any>()
@@ -42,15 +51,29 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    direct_messages/sent
 
-    Returns the 20 most recent direct messages sent by the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 outgoing DMs.
+    Returns the 20 most recent direct messages sent by the authenticating user. Includes detailed
+     information about the sender and recipient user. You can request up to 200 direct messages per
+     call, up to a maximum of 800 outgoing DMs.
     */
-    public func getSentDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, page: Int? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSentDirectMessages(
+        since sinceID: String? = nil,
+        maxID: String? = nil,
+        count: Int? = nil,
+        page: Int? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "direct_messages/sent.json"
 
         var parameters = Dictionary<String, Any>()
@@ -60,49 +83,84 @@ public extension Swifter {
         parameters["page"] ??= page
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    direct_messages/show
 
-    Returns a single direct message, specified by an id parameter. Like the /1.1/direct_messages.format request, this method will include the user objects of the sender and recipient.
+    Returns a single direct message, specified by an id parameter. Like the
+     /1.1/direct_messages.format request, this method will include the user objects of the sender
+     and recipient.
     */
-    public func showDirectMessage(forID id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showDirectMessage(
+        forID id: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "direct_messages/show.json"
         let parameters: [String: Any] = ["id" : id]
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     POST	direct_messages/destroy
 
-    Destroys the direct message specified in the required ID parameter. The authenticating user must be the recipient of the specified direct message.
+    Destroys the direct message specified in the required ID parameter. The authenticating user must
+     be the recipient of the specified direct message.
     */
-    public func destroyDirectMessage(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func destroyDirectMessage(
+        forID id: String,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "direct_messages/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	direct_messages/new
 
-    Sends a new direct message to the specified user from the authenticating user. Requires both the user and text parameters and must be a POST. Returns the sent message in the requested format if successful.
+    Sends a new direct message to the specified user from the authenticating user. Requires both the
+     user and text parameters and must be a POST. Returns the sent message in the requested format
+     if successful.
     */
-    public func sendDirectMessage(to userTag: UserTag, text: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func sendDirectMessage(
+        to userTag: UserTag,
+        text: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "direct_messages/new.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["text"] = text
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
 }

--- a/Sources/SwifterOAuthClient.swift
+++ b/Sources/SwifterOAuthClient.swift
@@ -44,19 +44,38 @@ internal class OAuthClient: SwifterClientProtocol  {
         self.consumerSecret = consumerSecret
     }
 
-    init(consumerKey: String, consumerSecret: String, accessToken: String, accessTokenSecret: String) {
+    init(
+        consumerKey: String,
+        consumerSecret: String,
+        accessToken: String,
+        accessTokenSecret: String)
+    {
         self.consumerKey = consumerKey
         self.consumerSecret = consumerSecret
 
-        let credentialAccessToken = Credential.OAuthAccessToken(key: accessToken, secret: accessTokenSecret)
+        let credentialAccessToken =
+            Credential.OAuthAccessToken(key: accessToken, secret: accessTokenSecret)
         self.credential = Credential(accessToken: credentialAccessToken)
     }
 
-    func get(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func get(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)!
 
         let request = HTTPRequest(url: url, method: .GET, parameters: parameters)
-        request.headers = ["Authorization": self.authorizationHeader(for: .GET, url: url, parameters: parameters, isMediaUpload: false)]
+        request.headers = ["Authorization":
+            self.authorizationHeader(for: .GET,
+                                     url: url,
+                                     parameters: parameters,
+                                     isMediaUpload: false)]
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure
@@ -66,7 +85,16 @@ internal class OAuthClient: SwifterClientProtocol  {
         return request
     }
 
-    func post(_ path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler?, downloadProgress: HTTPRequest.DownloadProgressHandler?, success: HTTPRequest.SuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+    func post(
+        _ path: String,
+        baseURL: TwitterURL,
+        parameters: Dictionary<String, Any>,
+        uploadProgress: HTTPRequest.UploadProgressHandler?,
+        downloadProgress: HTTPRequest.DownloadProgressHandler?,
+        success: HTTPRequest.SuccessHandler?,
+        failure: HTTPRequest.FailureHandler?)
+        -> HTTPRequest
+    {
         let url = URL(string: path, relativeTo: baseURL.url)!
         
         var parameters = parameters
@@ -92,7 +120,11 @@ internal class OAuthClient: SwifterClientProtocol  {
         }
 
         let request = HTTPRequest(url: url, method: .POST, parameters: parameters)
-        request.headers = ["Authorization": self.authorizationHeader(for: .POST, url: url, parameters: parameters, isMediaUpload: postData != nil)]
+        request.headers = ["Authorization":
+            self.authorizationHeader(for: .POST,
+                                     url: url,
+                                     parameters: parameters,
+                                     isMediaUpload: postData != nil)]
         request.downloadProgressHandler = downloadProgress
         request.successHandler = success
         request.failureHandler = failure
@@ -101,14 +133,23 @@ internal class OAuthClient: SwifterClientProtocol  {
 
         if let postData = postData {
             let fileName = postDataFileName ?? "media.jpg"
-            request.add(multipartData: postData, parameterName: postDataKey!, mimeType: "application/octet-stream", fileName: fileName)
+            request.add(multipartData: postData,
+                        parameterName: postDataKey!,
+                        mimeType: "application/octet-stream",
+                        fileName: fileName)
         }
 
         request.start()
         return request
     }
 
-    func authorizationHeader(for method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, isMediaUpload: Bool) -> String {
+    func authorizationHeader(
+        for method: HTTPMethodType,
+        url: URL,
+        parameters: Dictionary<String, Any>,
+        isMediaUpload: Bool)
+        -> String
+    {
         var authorizationParameters = Dictionary<String, Any>()
         authorizationParameters["oauth_version"] = OAuth.version
         authorizationParameters["oauth_signature_method"] =  OAuth.signatureMethod
@@ -126,9 +167,15 @@ internal class OAuthClient: SwifterClientProtocol  {
 
         let finalParameters = isMediaUpload ? authorizationParameters : combinedParameters
 
-        authorizationParameters["oauth_signature"] = self.oauthSignature(for: method, url: url, parameters: finalParameters, accessToken: self.credential?.accessToken)
+        authorizationParameters["oauth_signature"] =
+            self.oauthSignature(for: method,
+                                url: url,
+                                parameters: finalParameters,
+                                accessToken: self.credential?.accessToken)
 
-        let authorizationParameterComponents = authorizationParameters.urlEncodedQueryString(using: self.dataEncoding).components(separatedBy: "&").sorted()
+        let authorizationParameterComponents =
+                authorizationParameters.urlEncodedQueryString(using: self.dataEncoding)
+                .components(separatedBy: "&").sorted()
 
         var headerComponents = [String]()
         for component in authorizationParameterComponents {
@@ -141,11 +188,19 @@ internal class OAuthClient: SwifterClientProtocol  {
         return "OAuth " + headerComponents.joined(separator: ", ")
     }
 
-    func oauthSignature(for method: HTTPMethodType, url: URL, parameters: Dictionary<String, Any>, accessToken token: Credential.OAuthAccessToken?) -> String {
+    func oauthSignature(
+        for method: HTTPMethodType,
+        url: URL,
+        parameters: Dictionary<String, Any>,
+        accessToken token: Credential.OAuthAccessToken?)
+        -> String
+    {
         let tokenSecret = token?.secret.urlEncodedString() ?? ""
         let encodedConsumerSecret = self.consumerSecret.urlEncodedString()
         let signingKey = "\(encodedConsumerSecret)&\(tokenSecret)"
-        let parameterComponents = parameters.urlEncodedQueryString(using: dataEncoding).components(separatedBy: "&").sorted()
+        let parameterComponents =
+                parameters.urlEncodedQueryString(using: dataEncoding).components(separatedBy: "&")
+                .sorted()
         let parameterString = parameterComponents.joined(separator: "&")
         let encodedParameterString = parameterString.urlEncodedString()
         let encodedURL = url.absoluteString.urlEncodedString()

--- a/Sources/SwifterPlaces.swift
+++ b/Sources/SwifterPlaces.swift
@@ -32,20 +32,37 @@ public extension Swifter {
 
     Returns all the information about a known place.
     */
-    public func getGeoID(for placeID: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getGeoID(
+        for placeID: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "geo/id/\(placeID).json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    geo/reverse_geocode
 
-    Given a latitude and a longitude, searches for up to 20 places that can be used as a place_id when updating a status.
+    Given a latitude and a longitude, searches for up to 20 places that can be used as a place_id
+     when updating a status.
 
     This request is an informative call and will deliver generalized results about geography.
     */
-    public func getReverseGeocode(for coordinate: (lat: Double, long: Double), accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getReverseGeocode(
+        for coordinate: (lat: Double, long: Double),
+        accuracy: String? = nil,
+        granularity: String? = nil,
+        maxResults: Int? = nil,
+        callback: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "geo/reverse_geocode.json"
 
         var parameters = Dictionary<String, Any>()
@@ -63,14 +80,35 @@ public extension Swifter {
     /**
     GET    geo/search
 
-    Search for places that can be attached to a statuses/update. Given a latitude and a longitude pair, an IP address, or a name, this request will return a list of all the valid places that can be used as the place_id when updating a status.
+    Search for places that can be attached to a statuses/update. Given a latitude and a longitude
+     pair, an IP address, or a name, this request will return a list of all the valid places that
+     can be used as the place_id when updating a status.
 
-    Conceptually, a query can be made from the user's location, retrieve a list of places, have the user validate the location he or she is at, and then send the ID of this location with a call to POST statuses/update.
+    Conceptually, a query can be made from the user's location, retrieve a list of places, have the
+     user validate the location he or she is at, and then send the ID of this location with a call
+     to POST statuses/update.
 
-    This is the recommended method to use find places that can be attached to statuses/update. Unlike GET geo/reverse_geocode which provides raw data access, this endpoint can potentially re-order places with regards to the user who is authenticated. This approach is also preferred for interactive place matching with the user.
+    This is the recommended method to use find places that can be attached to statuses/update.
+     Unlike GET geo/reverse_geocode which provides raw data access, this endpoint can potentially
+     re-order places with regards to the user who is authenticated. This approach is also preferred
+     for interactive place matching with the user.
     */
-    public func searchGeo(coordinate: (lat: Double, long: Double)? = nil, query: String? = nil, ipAddress: String? = nil, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        assert(coordinate != nil || query != nil || ipAddress != nil, "At least one of the following parameters must be provided to access this resource: coordinate, ipAddress, or query")
+    public func searchGeo(
+        coordinate: (lat: Double, long: Double)? = nil,
+        query: String? = nil,
+        ipAddress: String? = nil,
+        accuracy: String? = nil,
+        granularity: String? = nil,
+        maxResults: Int? = nil,
+        containedWithin: String? = nil,
+        attributeStreetAddress: String? = nil,
+        callback: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        assert(coordinate != nil || query != nil || ipAddress != nil,
+               "At least one of the following parameters must be provided to access this resource: "
+               + "coordinate, ipAddress, or query")
 
         let path = "geo/search.json"
 
@@ -90,7 +128,11 @@ public extension Swifter {
         parameters["attribute:street_address"] ??= attributeStreetAddress
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -98,11 +140,20 @@ public extension Swifter {
 
     Locates places near the given coordinates which are similar in name.
 
-    Conceptually you would use this method to get a list of known places to choose from first. Then, if the desired place doesn't exist, make a request to POST geo/place to create a new one.
+    Conceptually you would use this method to get a list of known places to choose from first. Then,
+     if the desired place doesn't exist, make a request to POST geo/place to create a new one.
 
     The token contained in the response is the token needed to be able to create a new place.
     */
-    public func getSimilarPlaces(for coordinate: (lat: Double, long: Double), name: String, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSimilarPlaces(
+        for coordinate: (lat: Double, long: Double),
+        name: String,
+        containedWithin: String? = nil,
+        attributeStreetAddress: String? = nil,
+        callback: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "geo/similar_places.json"
 
         var parameters = Dictionary<String, Any>()
@@ -114,7 +165,11 @@ public extension Swifter {
         parameters["attribute:street_address"] ??= attributeStreetAddress
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterSavedSearches.swift
+++ b/Sources/SwifterSavedSearches.swift
@@ -32,21 +32,37 @@ public extension Swifter {
 
     Returns the authenticated user's saved search queries.
     */
-    public func getSavedSearchesList(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSavedSearchesList(
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "saved_searches/list.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    saved_searches/show/:id
 
-    Retrieve the information for the saved search represented by the given id. The authenticating user must be the owner of saved search ID being requested.
+    Retrieve the information for the saved search represented by the given id. The authenticating
+     user must be the owner of saved search ID being requested.
     */
-    public func showSavedSearch(for id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showSavedSearch(
+        for id: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "saved_searches/show/\(id).json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -54,24 +70,41 @@ public extension Swifter {
 
     Create a new saved search for the authenticated user. A user may only have 25 saved searches.
     */
-    public func createSavedSearch(for query: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func createSavedSearch(
+        for query: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "saved_searches/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["query"] = query
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST   saved_searches/destroy/:id
 
-    Destroys a saved search for the authenticating user. The authenticating user must be the owner of saved search id being destroyed.
+    Destroys a saved search for the authenticating user. The authenticating user must be the owner
+     of saved search id being destroyed.
     */
-    public func deleteSavedSearch(for id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func deleteSavedSearch(
+        for id: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "saved_searches/destroy/\(id).json"
 
-        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: [:],
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
 }

--- a/Sources/SwifterSearch.swift
+++ b/Sources/SwifterSearch.swift
@@ -32,12 +32,31 @@ public extension Swifter {
      
      Returns a collection of relevant Tweets matching a specified query.
      
-     Please note that Twitter’s search service and, by extension, the Search API is not meant to be an exhaustive source of Tweets. Not all Tweets will be indexed or made available via the search interface.
+     Please note that Twitter’s search service and, by extension, the Search API is not meant to be
+     an exhaustive source of Tweets. Not all Tweets will be indexed or made available via the search
+     interface.
      
-     In API v1.1, the response format of the Search API has been improved to return Tweet objects more similar to the objects you’ll find across the REST API and platform. However, perspectival attributes (fields that pertain to the perspective of the authenticating user) are not currently supported on this endpoint.
+     In API v1.1, the response format of the Search API has been improved to return Tweet objects
+     more similar to the objects you’ll find across the REST API and platform. However, perspectival
+     attributes (fields that pertain to the perspective of the authenticating user) are not
+     currently supported on this endpoint.
 
      */
-    public func searchTweet(using query: String, geocode: String? = nil, lang: String? = nil, locale: String? = nil, resultType: String? = nil, count: Int? = nil, until: String? = nil, sinceID: String? = nil, maxID: String? = nil, includeEntities: Bool? = nil, callback: String? = nil, success: ((JSON, _ searchMetadata: JSON) -> Void)? = nil, failure: @escaping FailureHandler) {
+    public func searchTweet(
+        using query: String,
+        geocode: String? = nil,
+        lang: String? = nil,
+        locale: String? = nil,
+        resultType: String? = nil,
+        count: Int? = nil,
+        until: String? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        includeEntities: Bool? = nil,
+        callback: String? = nil,
+        success: ((JSON, _ searchMetadata: JSON) -> Void)? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "search/tweets.json"
 
         var parameters = Dictionary<String, Any>()
@@ -53,9 +72,11 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["statuses"], json["search_metadata"])
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json["statuses"], json["search_metadata"])},
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterSpam.swift
+++ b/Sources/SwifterSpam.swift
@@ -30,15 +30,22 @@ public extension Swifter {
     /**
     POST   users/report_spam
 
-    Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST blocks/create on behalf of the authenticated user.
+    Report the specified user as a spam account to Twitter. Additionally performs the equivalent of
+     POST blocks/create on behalf of the authenticated user.
     */
-    public func reportSpam(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func reportSpam(
+        for userTag: UserTag,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "users/report_spam.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
 }

--- a/Sources/SwifterStreaming.swift
+++ b/Sources/SwifterStreaming.swift
@@ -27,22 +27,42 @@ import Foundation
 
 public extension Swifter {
     
-    typealias StallWarningHandler = (_ code: String?, _ message: String?, _ percentFull: Int?) -> Void
+    typealias StallWarningHandler =
+        (_ code: String?, _ message: String?, _ percentFull: Int?) -> Void
 
     /**
     POST	statuses/filter
 
-    Returns public statuses that match one or more filter predicates. Multiple parameters may be specified which allows most clients to use a single connection to the Streaming API. Both GET and POST requests are supported, but GET requests with too many parameters may cause the request to be rejected for excessive URL length. Use a POST request to avoid long URLs.
+    Returns public statuses that match one or more filter predicates. Multiple parameters may be
+     specified which allows most clients to use a single connection to the Streaming API. Both GET
+     and POST requests are supported, but GET requests with too many parameters may cause the
+     request to be rejected for excessive URL length. Use a POST request to avoid long URLs.
 
-    The track, follow, and locations fields should be considered to be combined with an OR operator. track=foo&follow=1234 returns Tweets matching "foo" OR created by user 1234.
+    The track, follow, and locations fields should be considered to be combined with an OR operator.
+     track=foo&follow=1234 returns Tweets matching "foo" OR created by user 1234.
 
-    The default access level allows up to 400 track keywords, 5,000 follow userids and 25 0.1-360 degree location boxes. If you need elevated access to the Streaming API, you should explore our partner providers of Twitter data here: https://dev.twitter.com/programs/twitter-certified-products/products#Certified-Data-Products
+    The default access level allows up to 400 track keywords, 5,000 follow userids and 25 0.1-360
+     degree location boxes. If you need elevated access to the Streaming API, you should explore our
+     partner providers of Twitter data here:
+     https://dev.twitter.com/programs/twitter-certified-products/products#Certified-Data-Products
 
     At least one predicate parameter (follow, locations, or track) must be specified.
     */
-    public func postTweetFilters(follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
-        
-        assert(follow != nil || track != nil || locations != nil, "At least one predicate parameter (follow, locations, or track) must be specified")
+    public func postTweetFilters(
+        follow: [String]? = nil,
+        track: [String]? = nil,
+        locations: [String]? = nil,
+        delimited: Bool? = nil,
+        stallWarnings: Bool? = nil,
+        filter_level: String? = nil,
+        language: [String]? = nil,
+        progress: SuccessHandler? = nil,
+        stallWarningHandler: StallWarningHandler? = nil,
+        failure: FailureHandler? = nil)
+        -> HTTPRequest
+    {
+        assert(follow != nil || track != nil || locations != nil,
+               "At least one predicate parameter (follow, locations, or track) must be specified")
 
         let path = "statuses/filter.json"
 
@@ -55,22 +75,42 @@ public extension Swifter {
         parameters["track"] ??= track?.joined(separator: ",")
         parameters["locations"] ??= locations?.joined(separator: ",")
 
-        return self.postJSON(path: path, baseURL: .stream, parameters: parameters, downloadProgress: { json, _ in
-            if let stallWarning = json["warning"].object {
-                stallWarningHandler?(stallWarning["code"]?.string, stallWarning["message"]?.string, stallWarning["percent_full"]?.integer)
-            } else {
-                progress?(json)
-            }
+        return self.postJSON(
+            path: path,
+            baseURL: .stream,
+            parameters: parameters,
+            downloadProgress: {
+                json, _ in
+                if let stallWarning = json["warning"].object {
+                    stallWarningHandler?(stallWarning["code"]?.string,
+                                         stallWarning["message"]?.string,
+                                         stallWarning["percent_full"]?.integer)
+                } else {
+                    progress?(json)
+                }
 
-            }, success: { json, _ in progress?(json) }, failure: failure)
+            },
+            success: { json, _ in progress?(json) },
+            failure: failure)
     }
 
     /**
     GET    statuses/sample
 
-    Returns a small random sample of all public statuses. The Tweets returned by the default access level are the same, so if two different clients connect to this endpoint, they will see the same Tweets.
+    Returns a small random sample of all public statuses. The Tweets returned by the default access
+     level are the same, so if two different clients connect to this endpoint, they will see the
+     same Tweets.
     */
-    public func streamRandomSampleTweets(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamRandomSampleTweets(
+        delimited: Bool? = nil,
+        stallWarnings: Bool? = nil,
+        filter_level: String? = nil,
+        language: [String]? = nil,
+        progress: SuccessHandler? = nil,
+        stallWarningHandler: StallWarningHandler? = nil,
+        failure: FailureHandler? = nil)
+        -> HTTPRequest
+    {
         let path = "statuses/sample.json"
 
         var parameters = Dictionary<String, Any>()
@@ -79,14 +119,23 @@ public extension Swifter {
         parameters["filter_level"] ??= filter_level
         parameters["language"] ??= language?.joined(separator: ",")
 
-        return self.getJSON(path: path, baseURL: .stream, parameters: parameters, downloadProgress: { json, _ in
-            if let stallWarning = json["warning"].object {
-                stallWarningHandler?(stallWarning["code"]?.string, stallWarning["message"]?.string, stallWarning["percent_full"]?.integer)
-            } else {
-                progress?(json)
-            }
+        return self.getJSON(
+                path: path,
+                baseURL: .stream,
+                parameters: parameters,
+                downloadProgress: {
+                    json, _ in
+                    if let stallWarning = json["warning"].object {
+                        stallWarningHandler?(stallWarning["code"]?.string,
+                                             stallWarning["message"]?.string,
+                                             stallWarning["percent_full"]?.integer)
+                    } else {
+                        progress?(json)
+                    }
 
-            }, success: { json, _ in progress?(json) }, failure: failure)
+                },
+                success: { json, _ in progress?(json) },
+                failure: failure)
     }
 
     /**
@@ -94,10 +143,22 @@ public extension Swifter {
 
     This endpoint requires special permission to access.
 
-    Returns all public statuses. Few applications require this level of access. Creative use of a combination of other resources and various access levels can satisfy nearly every application use case.
+    Returns all public statuses. Few applications require this level of access. Creative use of a
+     combination of other resources and various access levels can satisfy nearly every application
+     use case.
     */
     
-    public func streamFirehoseTweets(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamFirehoseTweets(
+        count: Int? = nil,
+        delimited: Bool? = nil,
+        stallWarnings: Bool? = nil,
+        filter_level: String? = nil,
+        language: [String]? = nil,
+        progress: SuccessHandler? = nil,
+        stallWarningHandler: StallWarningHandler? = nil,
+        failure: FailureHandler? = nil)
+        -> HTTPRequest
+    {
         let path = "statuses/firehose.json"
 
         var parameters = Dictionary<String, Any>()
@@ -107,22 +168,42 @@ public extension Swifter {
         parameters["filter_level"] ??= filter_level
         parameters["language"] ??= language?.joined(separator: ",")
 
-        return self.getJSON(path: path, baseURL: .stream, parameters: parameters, downloadProgress: { json, _ in
-            if let stallWarning = json["warning"].object {
-                stallWarningHandler?(stallWarning["code"]?.string, stallWarning["message"]?.string, stallWarning["percent_full"]?.integer)
-            } else {
-                progress?(json)
-            }
-
+        return self.getJSON(
+                path: path,
+                baseURL: .stream,
+                parameters: parameters,
+                downloadProgress: {
+                    json, _ in
+                    if let stallWarning = json["warning"].object {
+                        stallWarningHandler?(stallWarning["code"]?.string,
+                                             stallWarning["message"]?.string,
+                                             stallWarning["percent_full"]?.integer)
+                    } else {
+                        progress?(json)
+                    }
             }, success: { json, _ in progress?(json) }, failure: failure)
     }
 
     /**
     GET    user
 
-    Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
+    Streams messages for a single user, as described in User streams
+     https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func beginUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginUserStream(
+        delimited: Bool? = nil,
+        stallWarnings: Bool? = nil,
+        includeMessagesFromUserOnly: Bool = false,
+        includeReplies: Bool = false,
+        track: [String]? = nil, locations: [String]? = nil,
+        stringifyFriendIDs: Bool? = nil,
+        filter_level: String? = nil,
+        language: [String]? = nil,
+        progress: SuccessHandler? = nil,
+        stallWarningHandler: StallWarningHandler? = nil,
+        failure: FailureHandler? = nil)
+        -> HTTPRequest
+    {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
@@ -140,22 +221,41 @@ public extension Swifter {
             parameters["replies"] = "all"
         }
         
-        return self.getJSON(path: path, baseURL: .userStream, parameters: parameters, downloadProgress: { json, _ in
-            if let stallWarning = json["warning"].object {
-                stallWarningHandler?(stallWarning["code"]?.string, stallWarning["message"]?.string, stallWarning["percent_full"]?.integer)
-            } else {
-                progress?(json)
-            }
-
-            }, success: { json, _ in progress?(json) }, failure: failure)
+        return self.getJSON(
+                path: path,
+                baseURL: .userStream,
+                parameters: parameters,
+                downloadProgress: {
+                    json, _ in
+                    if let stallWarning = json["warning"].object {
+                        stallWarningHandler?(stallWarning["code"]?.string,
+                                             stallWarning["message"]?.string,
+                                             stallWarning["percent_full"]?.integer)
+                    } else {
+                        progress?(json)
+                    }
+                },
+                success: { json, _ in progress?(json) },
+                failure: failure)
     }
 
     /**
     GET    site
 
-    Streams messages for a set of users, as described in Site streams https://dev.twitter.com/docs/streaming-apis/streams/site
+    Streams messages for a set of users, as described in Site streams
+     https://dev.twitter.com/docs/streaming-apis/streams/site
     */
-    public func beginSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginSiteStream(
+        delimited: Bool? = nil,
+        stallWarnings: Bool? = nil,
+        restrictToUserMessages: Bool = false,
+        includeReplies: Bool = false,
+        stringifyFriendIDs: Bool? = nil,
+        progress: SuccessHandler? = nil,
+        stallWarningHandler: StallWarningHandler? = nil,
+        failure: FailureHandler? = nil)
+        -> HTTPRequest
+    {
         let path = "site.json"
 
         var parameters = Dictionary<String, Any>()
@@ -169,9 +269,18 @@ public extension Swifter {
             parameters["replies"] = "all"
         }
 
-        return self.getJSON(path: path, baseURL: .stream, parameters: parameters, downloadProgress: { json, _ in
-            stallWarningHandler?(json["warning"]["code"].string, json["warning"]["message"].string, json["warning"]["percent_full"].integer)
-            }, success: { json, _ in progress?(json) }, failure: failure)
+        return self.getJSON(
+                path: path,
+                baseURL: .stream,
+                parameters: parameters,
+                downloadProgress: {
+                    json, _ in
+                    stallWarningHandler?(json["warning"]["code"].string,
+                                         json["warning"]["message"].string,
+                                         json["warning"]["percent_full"].integer)
+                },
+                success: { json, _ in progress?(json) },
+                failure: failure)
     }
     
 }

--- a/Sources/SwifterSuggested.swift
+++ b/Sources/SwifterSuggested.swift
@@ -34,37 +34,64 @@ public extension Swifter {
 
     It is recommended that applications cache this data for no more than one hour.
     */
-    public func getUserSuggestions(slug: String, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserSuggestions(
+        slug: String,
+        lang: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "users/suggestions/\(slug).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    users/suggestions
 
-    Access to Twitter's suggested user list. This returns the list of suggested user categories. The category can be used in GET users/suggestions/:slug to get the users in that category.
+    Access to Twitter's suggested user list. This returns the list of suggested user categories. The
+     category can be used in GET users/suggestions/:slug to get the users in that category.
     */
-    public func getUsersSuggestions(lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(
+        lang: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "users/suggestions.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    users/suggestions/:slug/members
 
-    Access the users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user.
+    Access the users in a given category of the Twitter suggested user list and return their most
+     recent status if they are not a protected user.
     */
-    public func getUsersSuggestions(for slug: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(
+        for slug: String,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "users/suggestions/\(slug)/members.json"
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterTimelines.swift
+++ b/Sources/SwifterTimelines.swift
@@ -28,7 +28,18 @@ import Foundation
 public extension Swifter {
 
     // Convenience method
-    private func getTimeline(at path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    private func getTimeline(
+        at path: String,
+        parameters: Dictionary<String, Any>,
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        trimUser: Bool? = nil,
+        contributorDetails: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         var params = parameters
         params["count"] ??= count
         params["since_id"] ??= sinceID
@@ -37,23 +48,45 @@ public extension Swifter {
         params["contributor_details"] ??= contributorDetails
         params["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: params, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: params,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET	statuses/mentions_timeline
     Returns Tweets (*: mentions for the user)
 
-    Returns the 20 most recent mentions (tweets containing a users's @screen_name) for the authenticating user.
+    Returns the 20 most recent mentions (tweets containing a users's @screen_name) for the
+    authenticating user.
 
-    The timeline returned is the equivalent of the one seen when you view your mentions on twitter.com.
+    The timeline returned is the equivalent of the one seen when you view your mentions on
+     twitter.com.
 
     This method can only return up to 800 tweets.
     */
-    public func getMentionsTimelineTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler?) {
-        self.getTimeline(at: "statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getMentionsTimelineTweets(
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        trimUser: Bool? = nil,
+        contributorDetails: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler?)
+    {
+        self.getTimeline(at: "statuses/mentions_timeline.json",
+                         parameters: [:],
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         success: success,
+                         failure: failure)
     }
 
 
@@ -61,18 +94,42 @@ public extension Swifter {
     GET	statuses/user_timeline
     Returns Tweets (*: tweets for the user)
 
-    Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
+    Returns a collection of the most recent Tweets posted by the user indicated by the screen_name
+     or user_id parameters.
 
-    User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
+    User timelines belonging to protected users may only be requested when the authenticated user
+     either "owns" the timeline or is an approved follower of the owner.
 
-    The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
+    The timeline returned is the equivalent of the one seen when you view a user's profile on
+     twitter.com.
 
-    This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
+    This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other
+     statuses by the user is included in this total, regardless of whether include_rts is set to
+     false when requesting this resource.
     */
-    public func getTimeline(for userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTimeline(
+        for userID: String,
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        trimUser: Bool? = nil,
+        contributorDetails: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let parameters: Dictionary<String, Any> = ["user_id": userID]
 
-        self.getTimeline(at: "statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+        self.getTimeline(at: "statuses/user_timeline.json",
+                         parameters: parameters,
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         success: success,
+                         failure: failure)
     }
 
     /**
@@ -80,21 +137,62 @@ public extension Swifter {
 
     Returns Tweets (*: tweets from people the user follows)
 
-    Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
+    Returns a collection of the most recent Tweets and retweets posted by the authenticating user
+     and the users they follow. The home timeline is central to how most users interact with the
+     Twitter service.
 
-    Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow many users or follow users who tweet frequently.
+    Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow
+     many users or follow users who tweet frequently.
     */
-    public func getHomeTimeline(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        self.getTimeline(at: "statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getHomeTimeline(
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        trimUser: Bool? = nil,
+        contributorDetails: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        self.getTimeline(at: "statuses/home_timeline.json",
+                         parameters: [:],
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         success: success,
+                         failure: failure)
     }
 
     /**
     GET    statuses/retweets_of_me
 
-    Returns the most recent tweets authored by the authenticating user that have been retweeted by others. This timeline is a subset of the user's GET statuses/user_timeline. See Working with Timelines for instructions on traversing timelines.
+    Returns the most recent tweets authored by the authenticating user that have been retweeted by
+     others. This timeline is a subset of the user's GET statuses/user_timeline. See Working with
+     Timelines for instructions on traversing timelines.
     */
-    public func getRetweetsOfMe(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        self.getTimeline(at: "statuses/retweets_of_me.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getRetweetsOfMe(
+        count: Int? = nil,
+        sinceID: String? = nil,
+        maxID: String? = nil,
+        trimUser: Bool? = nil,
+        contributorDetails: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        self.getTimeline(at: "statuses/retweets_of_me.json",
+                         parameters: [:],
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         success: success,
+                         failure: failure)
     }
 
 }

--- a/Sources/SwifterTrends.swift
+++ b/Sources/SwifterTrends.swift
@@ -13,20 +13,33 @@ public extension Swifter {
     /**
     GET    trends/place
 
-    Returns the top 10 trending topics for a specific WOEID, if trending information is available for it.
+    Returns the top 10 trending topics for a specific WOEID, if trending information is available
+     for it.
 
-    The response is an array of "trend" objects that encode the name of the trending topic, the query parameter that can be used to search for the topic on Twitter Search, and the Twitter Search URL.
+    The response is an array of "trend" objects that encode the name of the trending topic, the
+     query parameter that can be used to search for the topic on Twitter Search, and the Twitter
+     Search URL.
 
-    This information is cached for 5 minutes. Requesting more frequently than that will not return any more data, and will count against your rate limit usage.
+    This information is cached for 5 minutes. Requesting more frequently than that will not return
+     any more data, and will count against your rate limit usage.
     */
-    public func getTrendsPlace(with woeid: String, excludeHashtags: Bool = false, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsPlace(
+        with woeid: String,
+        excludeHashtags: Bool = false,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "trends/place.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = woeid
         parameters["exclude"] = excludeHashtags ? "hashtags" : nil
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -34,31 +47,49 @@ public extension Swifter {
 
     Returns the locations that Twitter has trending topic information for.
 
-    The response is an array of "locations" that encode the location's WOEID and some other human-readable information such as a canonical name and country the location belongs in.
+    The response is an array of "locations" that encode the location's WOEID and some other
+     human-readable information such as a canonical name and country the location belongs in.
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getAvailableTrends(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getAvailableTrends(
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "trends/available.json"
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    trends/closest
 
-    Returns the locations that Twitter has trending topic information for, closest to a specified location.
+    Returns the locations that Twitter has trending topic information for, closest to a specified
+     location.
 
-    The response is an array of "locations" that encode the location's WOEID and some other human-readable information such as a canonical name and country the location belongs in.
+    The response is an array of "locations" that encode the location's WOEID and some other
+     human-readable information such as a canonical name and country the location belongs in.
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getClosestTrends(for coordinate: (lat: Double, long: Double), success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getClosestTrends(
+        for coordinate: (lat: Double, long: Double),
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "trends/closest.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lat"] = coordinate.lat
         parameters["long"] = coordinate.long
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
 }

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -32,35 +32,63 @@ public extension Swifter {
 
     Returns up to 100 of the first retweets of a given tweet.
     */
-    public func getRetweets(forTweetID id: String, count: Int? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRetweets(
+        forTweetID id: String,
+        count: Int? = nil,
+        trimUser: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/retweets/\(id).json"
         var parameters = Dictionary<String, Any>()
         parameters["count"] ??= count
         parameters["trim_user"] ??= trimUser
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    statuses/show/:id
 
-    Returns a single Tweet, specified by the id parameter. The Tweet's author will also be embedded within the tweet.
+    Returns a single Tweet, specified by the id parameter. The Tweet's author will also be embedded
+     within the tweet.
 
-    See Embeddable Timelines, Embeddable Tweets, and GET statuses/oembed for tools to render Tweets according to Display Requirements.
+    See Embeddable Timelines, Embeddable Tweets, and GET statuses/oembed for tools to render Tweets
+     according to Display Requirements.
 
     # About Geo
 
-    If there is no geotag for a status, then there will be an empty <geo/> or "geo" : {}. This can only be populated if the user has used the Geotagging API to send a statuses/update.
+    If there is no geotag for a status, then there will be an empty <geo/> or "geo" : {}. This can
+     only be populated if the user has used the Geotagging API to send a statuses/update.
 
-    The JSON response mostly uses conventions laid out in GeoJSON. Unfortunately, the coordinates that Twitter renders are reversed from the GeoJSON specification (GeoJSON specifies a longitude then a latitude, whereas we are currently representing it as a latitude then a longitude). Our JSON renders as: "geo": { "type":"Point", "coordinates":[37.78029, -122.39697] }
+    The JSON response mostly uses conventions laid out in GeoJSON. Unfortunately, the coordinates
+     that Twitter renders are reversed from the GeoJSON specification (GeoJSON specifies a longitude
+     then a latitude, whereas we are currently representing it as a latitude then a longitude). Our
+     JSON renders as: "geo": { "type":"Point", "coordinates":[37.78029, -122.39697] }
 
     # Contributors
 
-    If there are no contributors for a Tweet, then there will be an empty or "contributors" : {}. This field will only be populated if the user has contributors enabled on his or her account -- this is a beta feature that is not yet generally available to all.
+    If there are no contributors for a Tweet, then there will be an empty or "contributors" : {}.
+     This field will only be populated if the user has contributors enabled on his or her account --
+     this is a beta feature that is not yet generally available to all.
 
-    This object contains an array of user IDs for users who have contributed to this status (an example of a status that has been contributed to is this one). In practice, there is usually only one ID in this array. The JSON renders as such "contributors":[8285392].
+    This object contains an array of user IDs for users who have contributed to this status (an
+     example of a status that has been contributed to is this one). In practice, there is usually
+     only one ID in this array. The JSON renders as such "contributors":[8285392].
     */
-    public func getTweet(forID id: String, count: Int? = nil, trimUser: Bool? = nil, includeMyRetweet: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTweet(
+        forID id: String,
+        count: Int? = nil,
+        trimUser: Bool? = nil,
+        includeMyRetweet: Bool? = nil,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -70,46 +98,91 @@ public extension Swifter {
         parameters["include_my_retweet"] ??= includeMyRetweet
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     POST	statuses/destroy/:id
 
-    Destroys the status specified by the required ID parameter. The authenticating user must be the author of the specified status. Returns the destroyed status if successful.
+    Destroys the status specified by the required ID parameter. The authenticating user must be the
+     author of the specified status. Returns the destroyed status if successful.
     */
-    public func destroyTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func destroyTweet(
+        forID id: String,
+        trimUser: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/destroy/\(id).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	statuses/update
 
-    Updates the authenticating user's current status, also known as tweeting. To upload an image to accompany the tweet, use POST media/upload.
+    Updates the authenticating user's current status, also known as tweeting. To upload an image to
+     accompany the tweet, use POST media/upload.
 
-    For each update attempt, the update text is compared with the authenticating user's recent tweets. Any attempt that would result in duplication will be blocked, resulting in a 403 error. Therefore, a user cannot submit the same status twice in a row.
+    For each update attempt, the update text is compared with the authenticating user's recent
+     tweets. Any attempt that would result in duplication will be blocked, resulting in a 403 error.
+     Therefore, a user cannot submit the same status twice in a row.
 
-    While not rate limited by the API a user is limited in the number of tweets they can create at a time. If the number of updates posted by the user reaches the current allowed limit this method will return an HTTP 403 error.
+    While not rate limited by the API a user is limited in the number of tweets they can create at a
+     time. If the number of updates posted by the user reaches the current allowed limit this method
+     will return an HTTP 403 error.
 
-    - Any geo-tagging parameters in the update will be ignored if geo_enabled for the user is false (this is the default setting for all users unless the user has enabled geolocation in their settings)
-    - The number of digits passed the decimal separator passed to lat, up to 8, will be tracked so that the lat is returned in a status object it will have the same number of digits after the decimal separator.
-    - Please make sure to use to use a decimal point as the separator (and not the decimal comma) for the latitude and the longitude - usage of the decimal comma will cause the geo-tagged portion of the status update to be dropped.
-    - For JSON, the response mostly uses conventions described in GeoJSON. Unfortunately, the geo object has coordinates that Twitter renderers are reversed from the GeoJSON specification (GeoJSON specifies a longitude then a latitude, whereas we are currently representing it as a latitude then a longitude. Our JSON renders as: "geo": { "type":"Point", "coordinates":[37.78217, -122.40062] }
-    - The coordinates object is replacing the geo object (no deprecation date has been set for the geo object yet) -- the difference is that the coordinates object, in JSON, is now rendered correctly in GeoJSON.
-    - If a place_id is passed into the status update, then that place will be attached to the status. If no place_id was explicitly provided, but latitude and longitude are, we attempt to implicitly provide a place by calling geo/reverse_geocode.
-    - Users will have the ability, from their settings page, to remove all the geotags from all their tweets en masse. Currently we are not doing any automatic scrubbing nor providing a method to remove geotags from individual tweets.
+    - Any geo-tagging parameters in the update will be ignored if geo_enabled for the user is false
+     (this is the default setting for all users unless the user has enabled geolocation in their
+     settings)
+    - The number of digits passed the decimal separator passed to lat, up to 8, will be tracked so
+     that the lat is returned in a status object it will have the same number of digits after the
+     decimal separator.
+    - Please make sure to use to use a decimal point as the separator (and not the decimal comma)
+     for the latitude and the longitude - usage of the decimal comma will cause the geo-tagged
+     portion of the status update to be dropped.
+    - For JSON, the response mostly uses conventions described in GeoJSON. Unfortunately, the geo
+     object has coordinates that Twitter renderers are reversed from the GeoJSON specification
+     (GeoJSON specifies a longitude then a latitude, whereas we are currently representing it as a
+     latitude then a longitude. Our JSON renders as:
+     "geo": { "type":"Point", "coordinates":[37.78217, -122.40062] }
+    - The coordinates object is replacing the geo object (no deprecation date has been set for the
+     geo object yet) -- the difference is that the coordinates object, in JSON, is now rendered
+     correctly in GeoJSON.
+    - If a place_id is passed into the status update, then that place will be attached to the
+     status. If no place_id was explicitly provided, but latitude and longitude are, we attempt to
+     implicitly provide a place by calling geo/reverse_geocode.
+    - Users will have the ability, from their settings page, to remove all the geotags from all
+     their tweets en masse. Currently we are not doing any automatic scrubbing nor providing a
+     method to remove geotags from individual tweets.
 
     See:
 
     - https://dev.twitter.com/notifications/multiple-media-entities-in-tweets
     - https://dev.twitter.com/docs/api/multiple-media-extended-entities
     */
-    public func postTweet(status: String, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, media_ids: [String] = [], success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postTweet(
+        status: String,
+        inReplyToStatusID: String? = nil,
+        coordinate: (lat: Double, long: Double)? = nil,
+        placeID: Double? = nil,
+        displayCoordinates: Bool? = nil,
+        trimUser: Bool? = nil,
+        media_ids: [String] = [],
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path: String = "statuses/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -135,7 +208,16 @@ public extension Swifter {
             }, failure: failure)
     }
 
-    public func postTweet(status: String, media: Data, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postTweet(
+        status: String,
+        media: Data,
+        inReplyToStatusID: String? = nil,
+        coordinate: (lat: Double, long: Double)? = nil,
+        placeID: Double? = nil, displayCoordinates: Bool? = nil,
+        trimUser: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path: String = "statuses/update_with_media.json"
 
         var parameters = Dictionary<String, Any>()
@@ -154,29 +236,42 @@ public extension Swifter {
             parameters["display_coordinates"] = true
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	media/upload
 
-    Upload media (images) to Twitter for use in a Tweet or Twitter-hosted Card. For uploading videos or for chunked image uploads (useful for lower bandwidth connections), see our chunked POST media/upload endpoint.
+    Upload media (images) to Twitter for use in a Tweet or Twitter-hosted Card. For uploading videos
+     or for chunked image uploads (useful for lower bandwidth connections), see our chunked POST
+     media/upload endpoint.
 
     See:
 
     - https://dev.twitter.com/rest/public/uploading-media
     - https://dev.twitter.com/rest/reference/post/media/upload
     */
-    public func postMedia(_ media: Data, additionalOwners: UsersTag? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postMedia(
+        _ media: Data,
+        additionalOwners: UsersTag? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path: String = "media/upload.json"
         var parameters = Dictionary<String, Any>()
         parameters["media"] = media
         parameters["additional_owers"] ??= additionalOwners?.value
         parameters[Swifter.DataParameters.dataKey] = "media"
 
-        self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .upload,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -186,17 +281,27 @@ public extension Swifter {
 
     - This method is subject to update limits. A HTTP 403 will be returned if this limit as been hit.
     - Twitter will ignore attempts to perform duplicate retweets.
-    - The retweet_count will be current as of when the payload is generated and may not reflect the exact count. It is intended as an approximation.
+    - The retweet_count will be current as of when the payload is generated and may not reflect
+     the exact count. It is intended as an approximation.
 
     Returns Tweets (1: the new tweet)
     */
-    public func retweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func retweetTweet(
+        forID id: String,
+        trimUser: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/retweet/\(id).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
     
     /**
@@ -204,30 +309,58 @@ public extension Swifter {
      
      Untweets a retweeted status. Returns the original Tweet with retweet details embedded.
      
-     - This method is subject to update limits. A HTTP 429 will be returned if this limit has been hit.
-     - The untweeted retweet status ID must be authored by the user backing the authentication token.
-     - An application must have write privileges to POST. A HTTP 401 will be returned for read-only applications.
-     - When passing a source status ID instead of the retweet status ID a HTTP 200 response will be returned with the same Tweet object but no action.
+     - This method is subject to update limits. A HTTP 429 will be returned if this limit has been
+     hit.
+     - The untweeted retweet status ID must be authored by the user backing the authentication
+     token.
+     - An application must have write privileges to POST. A HTTP 401 will be returned for read-only
+     applications.
+     - When passing a source status ID instead of the retweet status ID a HTTP 200 response will be
+     returned with the same Tweet object but no action.
      
      Returns Tweets (1: the original tweet)
      */
-    public func UnretweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func UnretweetTweet(
+        forID id: String,
+        trimUser: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/unretweet/\(id).json"
         
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET    statuses/oembed
 
-    Returns information allowing the creation of an embedded representation of a Tweet on third party sites. See the oEmbed specification for information about the response format.
+    Returns information allowing the creation of an embedded representation of a Tweet on third
+     party sites. See the oEmbed specification for information about the response format.
 
-    While this endpoint allows a bit of customization for the final appearance of the embedded Tweet, be aware that the appearance of the rendered Tweet may change over time to be consistent with Twitter's Display Requirements. Do not rely on any class or id parameters to stay constant in the returned markup.
+    While this endpoint allows a bit of customization for the final appearance of the embedded
+     Tweet, be aware that the appearance of the rendered Tweet may change over time to be consistent
+     with Twitter's Display Requirements. Do not rely on any class or id parameters to stay constant
+     in the returned markup.
     */
-    public func oembedInfo(forID id: String, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func oembedInfo(
+        forID id: String,
+        maxWidth: Int? = nil,
+        hideMedia: Bool? = nil,
+        hideThread: Bool? = nil,
+        omitScript: Bool? = nil,
+        align: String? = nil,
+        related: String? = nil,
+        lang: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -240,10 +373,25 @@ public extension Swifter {
         parameters["related"] ??= related
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
-    public func oembedInfo(forUrl url: URL, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func oembedInfo(
+        forUrl url: URL,
+        maxWidth: Int? = nil,
+        hideMedia: Bool? = nil,
+        hideThread: Bool? = nil,
+        omitScript: Bool? = nil,
+        align: String? = nil,
+        related: String? = nil,
+        lang: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -256,17 +404,29 @@ public extension Swifter {
         parameters["related"] ??= related
         parameters["lang"] ??= lang
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET    statuses/retweeters/ids
 
-    Returns a collection of up to 100 user IDs belonging to users who have retweeted the tweet specified by the id parameter.
+    Returns a collection of up to 100 user IDs belonging to users who have retweeted the tweet
+     specified by the id parameter.
 
-    This method offers similar data to GET statuses/retweets/:id and replaces API v1's GET statuses/:id/retweeted_by/ids method.
+    This method offers similar data to GET statuses/retweets/:id and replaces API v1's GET
+     statuses/:id/retweeted_by/ids method.
     */
-    public func tweetRetweeters(forID id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func tweetRetweeters(
+        forID id: String,
+        cursor: String? = nil,
+        stringifyIDs: Bool? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/retweeters/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -274,17 +434,34 @@ public extension Swifter {
         parameters["cursor"] ??= cursor
         parameters["stringify_ids"] ??= stringifyIDs
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
     GET statuses/lookup
 
-    Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by comma-separated values passed to the id parameter. This method is especially useful to get the details (hydrate) a collection of Tweet IDs. GET statuses/show/:id is used to retrieve a single tweet object.
+    Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by
+     comma-separated values passed to the id parameter. This method is especially useful to get the
+     details (hydrate) a collection of Tweet IDs. GET statuses/show/:id is used to retrieve a single
+     tweet object.
     */
-    public func lookupTweets(for tweetIDs: [String], includeEntities: Bool? = nil, map: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func lookupTweets(
+        for tweetIDs: [String],
+        includeEntities: Bool? = nil,
+        map: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "statuses/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -292,7 +469,11 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["map"] ??= map
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
     
 }

--- a/Sources/SwifterUsers.swift
+++ b/Sources/SwifterUsers.swift
@@ -30,27 +30,43 @@ public extension Swifter {
     /**
     GET    account/settings
 
-    Returns settings (including current trend, geo and sleep time information) for the authenticating user.
+    Returns settings (including current trend, geo and sleep time information) for the
+     authenticating user.
     */
     public func getAccountSettings(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/settings.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: [:],
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET	account/verify_credentials
 
-    Returns an HTTP 200 OK response code and a representation of the requesting user if authentication was successful; returns a 401 status code and an error message if not. Use this method to test if supplied user credentials are valid.
+    Returns an HTTP 200 OK response code and a representation of the requesting user if
+     authentication was successful; returns a 401 status code and an error message if not. Use this
+     method to test if supplied user credentials are valid.
     */
-    public func verifyAccountCredentials(includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func verifyAccountCredentials(
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "account/verify_credentials.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -58,8 +74,23 @@ public extension Swifter {
 
     Updates the authenticating user's settings.
     */
-    public func updateAccountSettings(trendLocationWOEID: String? = nil, sleepTimeEnabled: Bool? = nil, startSleepTime: Int? = nil, endSleepTime: Int? = nil, timeZone: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        assert(trendLocationWOEID != nil || sleepTimeEnabled != nil || startSleepTime != nil || endSleepTime != nil || timeZone != nil || lang != nil, "At least one or more should be provided when executing this request")
+    public func updateAccountSettings(
+        trendLocationWOEID: String? = nil,
+        sleepTimeEnabled: Bool? = nil,
+        startSleepTime: Int? = nil,
+        endSleepTime: Int? = nil,
+        timeZone: String? = nil,
+        lang: String? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        assert(trendLocationWOEID != nil ||
+               sleepTimeEnabled != nil   ||
+               startSleepTime != nil     ||
+               endSleepTime != nil       ||
+               timeZone != nil           ||
+               lang != nil,
+               "At least one or more should be provided when executing this request")
 
         let path = "account/settings.json"
 
@@ -71,16 +102,35 @@ public extension Swifter {
         parameters["time_zone"] ??= timeZone
         parameters["lang"] ??= lang
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	account/update_profile
 
-    Sets values that users are able to set under the "Account" tab of their settings page. Only the parameters specified will be updated.
+    Sets values that users are able to set under the "Account" tab of their settings page. Only the
+     parameters specified will be updated.
     */
-    public func updateUserProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        assert(name != nil || url != nil || location != nil || description != nil || includeEntities != nil || skipStatus != nil)
+    public func updateUserProfile(
+        name: String? = nil,
+        url: String? = nil,
+        location: String? = nil,
+        description: String? = nil,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        assert(name != nil            ||
+               url != nil             ||
+               location != nil        ||
+               description != nil     ||
+               includeEntities != nil ||
+               skipStatus != nil)
 
         let path = "account/update_profile.json"
 
@@ -92,16 +142,30 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	account/update_profile_background_image
 
-    Updates the authenticating user's profile background image. This method can also be used to enable or disable the profile background image. Although each parameter is marked as optional, at least one of image, tile or use must be provided when making this request.
+    Updates the authenticating user's profile background image. This method can also be used to
+     enable or disable the profile background image. Although each parameter is marked as optional,
+     at least one of image, tile or use must be provided when making this request.
     */
-    public func updateProfileBackground(using imageData: Data, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        assert(title != nil || use != nil, "At least one of image, tile or use must be provided when making this request")
+    public func updateProfileBackground(
+        using imageData: Data,
+        title: String? = nil,
+        includeEntities: Bool? = nil,
+        use: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
+        assert(title != nil || use != nil,
+               "At least one of image, tile or use must be provided when making this request")
 
         let path = "account/update_profile_background_image.json"
 
@@ -111,15 +175,31 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["use"] ??= use
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	account/update_profile_colors
 
-    Sets one or more hex values that control the color scheme of the authenticating user's profile page on twitter.com. Each parameter's value must be a valid hexidecimal value, and may be either three or six characters (ex: #fff or #ffffff).
+    Sets one or more hex values that control the color scheme of the authenticating user's profile
+     page on twitter.com. Each parameter's value must be a valid hexidecimal value, and may be
+     either three or six characters (ex: #fff or #ffffff).
     */
-    public func updateProfileColors(backgroundColor: String? = nil, linkColor: String? = nil, sidebarBorderColor: String? = nil, sidebarFillColor: String? = nil, textColor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func updateProfileColors(
+        backgroundColor: String? = nil,
+        linkColor: String? = nil,
+        sidebarBorderColor: String? = nil,
+        sidebarFillColor: String? = nil,
+        textColor: String? = nil,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "account/update_profile_colors.json"
 
         var parameters = Dictionary<String, Any>()
@@ -131,17 +211,30 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	account/update_profile_image
 
-    Updates the authenticating user's profile image. Note that this method expects raw multipart data, not a URL to an image.
+    Updates the authenticating user's profile image. Note that this method expects raw multipart
+     data, not a URL to an image.
 
-    This method asynchronously processes the uploaded file before updating the user's profile image URL. You can either update your local cache the next time you request the user's information, or, at least 5 seconds after uploading the image, ask for the updated URL using GET users/show.
+    This method asynchronously processes the uploaded file before updating the user's profile image
+     URL. You can either update your local cache the next time you request the user's information,
+     or, at least 5 seconds after uploading the image, ask for the updated URL using GET users/show.
     */
-    public func updateProfileImage(using imageData: Data, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileImage(
+        using imageData: Data,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "account/update_profile_image.json"
 
         var parameters = Dictionary<String, Any>()
@@ -149,7 +242,11 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -157,7 +254,13 @@ public extension Swifter {
 
     Returns a collection of user objects that the authenticating user is blocking.
     */
-    public func getBlockedUsers(includeEntities: Bool? = nil, skipStatus: Bool? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getBlockedUsers(
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        cursor: String? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "blocks/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -165,9 +268,17 @@ public extension Swifter {
         parameters["skip_status"] ??= skipStatus
         parameters["cursor"] ??= cursor
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
@@ -175,24 +286,45 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user is blocking.
     */
-    public func getBlockedUsersIDs(stringifyIDs: String? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func getBlockedUsersIDs(
+        stringifyIDs: String? = nil,
+        cursor: String? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "blocks/ids.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["stringify_ids"] ??= stringifyIDs
         parameters["cursor"] ??= cursor
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
 
     /**
     POST	blocks/create
 
-    Blocks the specified user from following the authenticating user. In addition the blocked user will not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend relationship exists it is destroyed.
+    Blocks the specified user from following the authenticating user. In addition the blocked user
+     will not show in the authenticating users mentions or timeline (unless retweeted by another
+     user). If a follow or friend relationship exists it is destroyed.
     */
-    public func blockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func blockUser(
+        for userTag: UserTag,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "blocks/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -200,15 +332,27 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST	blocks/destroy
 
-    Un-blocks the user specified in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format when successful. If relationships existed before the block was instated, they will not be restored.
+    Un-blocks the user specified in the ID parameter for the authenticating user. Returns the
+     un-blocked user in the requested format when successful. If relationships existed before the
+     block was instated, they will not be restored.
     */
-    public func unblockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func unblockUser(
+        for userTag: UserTag,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "blocks/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -216,61 +360,101 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     GET    users/lookup
 
-    Returns fully-hydrated user objects for up to 100 users per request, as specified by comma-separated values passed to the user_id and/or screen_name parameters.
+    Returns fully-hydrated user objects for up to 100 users per request, as specified by
+     comma-separated values passed to the user_id and/or screen_name parameters.
 
-    This method is especially useful when used in conjunction with collections of user IDs returned from GET friends/ids and GET followers/ids.
+    This method is especially useful when used in conjunction with collections of user IDs returned
+     from GET friends/ids and GET followers/ids.
 
     GET users/show is used to retrieve a single user object.
 
     There are a few things to note when using this method.
 
-    - You must be following a protected user to be able to see their most recent status update. If you don't follow a protected user their status will be removed.
+    - You must be following a protected user to be able to see their most recent status update. If
+     you don't follow a protected user their status will be removed.
     - The order of user IDs or screen names may not match the order of users in the returned array.
-    - If a requested user is unknown, suspended, or deleted, then that user will not be returned in the results list.
-    - If none of your lookup criteria can be satisfied by returning a user object, a HTTP 404 will be thrown.
+    - If a requested user is unknown, suspended, or deleted, then that user will not be returned in
+     the results list.
+    - If none of your lookup criteria can be satisfied by returning a user object, a HTTP 404 will
+     be thrown.
     - You are strongly encouraged to use a POST for larger requests.
     */
-    public func lookupUsers(for usersTag: UsersTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func lookupUsers(
+        for usersTag: UsersTag,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[usersTag.key] = usersTag.value
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    users/show
 
-    Returns a variety of information about the user specified by the required user_id or screen_name parameter. The author's most recent Tweet will be returned inline when possible. GET users/lookup is used to retrieve a bulk collection of user objects.
+    Returns a variety of information about the user specified by the required user_id or screen_name
+     parameter. The author's most recent Tweet will be returned inline when possible. GET
+     users/lookup is used to retrieve a bulk collection of user objects.
 
-    You must be following a protected user to be able to see their most recent Tweet. If you don't follow a protected user, the users Tweet will be removed. A Tweet will not always be returned in the current_status field.
+    You must be following a protected user to be able to see their most recent Tweet. If you don't
+     follow a protected user, the users Tweet will be removed. A Tweet will not always be returned
+     in the current_status field.
     */
-    public func showUser(for userTag: UserTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func showUser(
+        for userTag: UserTag,
+        includeEntities: Bool? = nil,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "users/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
     GET    users/search
 
-    Provides a simple, relevance-based search interface to public user accounts on Twitter. Try querying by topical interest, full name, company name, location, or other criteria. Exact match searches are not supported.
+    Provides a simple, relevance-based search interface to public user accounts on Twitter. Try
+     querying by topical interest, full name, company name, location, or other criteria. Exact
+     match searches are not supported.
 
     Only the first 1,000 matching results are available.
     */
-    public func searchUsers(using query: String, page: Int?, count: Int?, includeEntities: Bool?, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func searchUsers(
+        using query: String,
+        page: Int?,
+        count: Int?,
+        includeEntities: Bool?,
+        success: SuccessHandler? = nil,
+        failure: @escaping FailureHandler)
+    {
         let path = "users/search.json"
 
         var parameters = Dictionary<String, Any>()
@@ -279,7 +463,11 @@ public extension Swifter {
         parameters["count"] ??= count
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path,
+                     baseURL: .api,
+                     parameters: parameters,
+                     success: { json, _ in success?(json) },
+                     failure: failure)
     }
 
     /**
@@ -287,27 +475,48 @@ public extension Swifter {
 
     Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon success.
     */
-    public func removeProfileBanner(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func removeProfileBanner(
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "account/remove_profile_banner.json"
 
-        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: [:],
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
     POST    account/update_profile_banner
 
-    Uploads a profile banner on behalf of the authenticating user. For best results, upload an <5MB image that is exactly 1252px by 626px. Images will be resized for a number of display options. Users with an uploaded profile banner will have a profile_banner_url node in their Users objects. More information about sizing variations can be found in User Profile Images and Banners and GET users/profile_banner.
+    Uploads a profile banner on behalf of the authenticating user. For best results, upload an <5MB
+     image that is exactly 1252px by 626px. Images will be resized for a number of display options.
+     Users with an uploaded profile banner will have a profile_banner_url node in their Users
+     objects. More information about sizing variations can be found in User Profile Images and
+     Banners and GET users/profile_banner.
 
-    Profile banner images are processed asynchronously. The profile_banner_url and its variant sizes will not necessary be available directly after upload.
+    Profile banner images are processed asynchronously. The profile_banner_url and its variant sizes
+     will not necessary be available directly after upload.
 
-    If providing any one of the height, width, offset_left, or offset_top parameters, you must provide all of the sizing parameters.
+    If providing any one of the height, width, offset_left, or offset_top parameters, you must
+     provide all of the sizing parameters.
 
     HTTP Response Codes
     200, 201, 202	Profile banner image succesfully uploaded
     400	Either an image was not provided or the image data could not be processed
     422	The image could not be resized or is too large.
     */
-    public func updateProfileBanner(using imageData: Data, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileBanner(
+        using imageData: Data,
+        width: Int? = nil,
+        height: Int? = nil,
+        offsetLeft: Int? = nil,
+        offsetTop: Int? = nil,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "account/update_profile_banner.json"
 
         var parameters = Dictionary<String, Any>()
@@ -317,19 +526,34 @@ public extension Swifter {
         parameters["offset_left"] ??= offsetLeft
         parameters["offset_top"] ??= offsetTop
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: { json, _ in success?(json) },
+            failure: failure)
     }
 
     /**
     GET    users/profile_banner
 
-    Returns a map of the available size variations of the specified user's profile banner. If the user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string manipulation on the profile_banner_url returned in user objects as described in User Profile Images and Banners.
+    Returns a map of the available size variations of the specified user's profile banner. If the
+     user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be
+     used instead of string manipulation on the profile_banner_url returned in user objects as
+     described in User Profile Images and Banners.
     */
-    public func getProfileBanner(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getProfileBanner(
+        for userTag: UserTag,
+        success: SuccessHandler? = nil,
+        failure: FailureHandler? = nil) {
         let path = "users/profile_banner.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -337,15 +561,23 @@ public extension Swifter {
 
     Mutes the user specified in the ID parameter for the authenticating user.
 
-    Returns the muted user in the requested format when successful. Returns a string describing the failure condition when unsuccessful.
+    Returns the muted user in the requested format when successful. Returns a string describing the
+     failure condition when unsuccessful.
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func muteUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func muteUser(for userTag: UserTag,
+                         success: SuccessHandler? = nil,
+                         failure: FailureHandler? = nil)
+    {
         let path = "mutes/users/create.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path,
+                      baseURL: .api,
+                      parameters: parameters,
+                      success: { json, _ in success?(json) },
+                      failure: failure)
     }
 
     /**
@@ -353,19 +585,27 @@ public extension Swifter {
 
     Un-mutes the user specified in the ID parameter for the authenticating user.
 
-    Returns the unmuted user in the requested format when successful. Returns a string describing the failure condition when unsuccessful.
+    Returns the unmuted user in the requested format when successful. Returns a string describing
+     the failure condition when unsuccessful.
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func unmuteUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unmuteUser(for userTag: UserTag,
+                           success: SuccessHandler? = nil,
+                           failure: FailureHandler? = nil) {
         let path = "mutes/users/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json)
-            }, failure: failure)
+        self.postJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: { json, _ in
+                success?(json)
+            },
+            failure: failure)
     }
 
     /**
@@ -373,15 +613,27 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user has muted.
     */
-    public func getMuteUsersIDs(cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getMuteUsersIDs(
+        cursor: String? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "mutes/users/ids.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["cursor"] ??= cursor
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: {
+                json, _ in
+                success?(json["ids"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
     /**
@@ -389,7 +641,13 @@ public extension Swifter {
     
     Returns an array of user objects the authenticating user has muted.
     */
-    public func getMuteUsers(cursor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getMuteUsers(
+        cursor: String? = nil,
+        includeEntities: Bool? = nil,
+        skipStatus: Bool? = nil,
+        success: CursorSuccessHandler? = nil,
+        failure: FailureHandler? = nil)
+    {
         let path = "mutes/users/list.json"
         
         var parameters = Dictionary<String, Any>()
@@ -397,9 +655,16 @@ public extension Swifter {
         parameters["skip_status"] ??= skipStatus
         parameters["cursor"] ??= cursor
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
-            success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+        self.getJSON(
+            path: path,
+            baseURL: .api,
+            parameters: parameters,
+            success: { json, _ in
+                success?(json["users"],
+                         json["previous_cursor_str"].string,
+                         json["next_cursor_str"].string)
+            },
+            failure: failure)
     }
     
 }

--- a/Sources/URL++.swift
+++ b/Sources/URL++.swift
@@ -38,7 +38,9 @@ extension URL {
             absoluteURLString = absoluteURLString[0..<absoluteURLString.utf16.count]
         }
         
-        let urlString = absoluteURLString + (absoluteURLString.range(of: "?") != nil ? "&" : "?") + queryString
+        let urlString = absoluteURLString
+                        + (absoluteURLString.range(of: "?") != nil ? "&" : "?")
+                        + queryString
         return URL(string: urlString)!
     }
 


### PR DESCRIPTION
This pull request gets rid of all of the incredibly long lines that up until now have been part of the project, making method signatures in particular much easier to read.