### PR TITLE
Add support for getting raw and/or decoded data via Decodable protocol

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -203,6 +203,52 @@ public enum JSON : Equatable, CustomStringConvertible {
     
 }
 
+extension JSON: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer() {
+            if let string = try? container.decode(String.self) {
+                self = .string(string)
+            } else if let bool = try? container.decode(Bool.self) {
+                self = .bool(bool)
+            } else if let number = try? container.decode(Double.self) {
+                self = .number(number)
+            } else {
+                self = .invalid
+            }
+        } else if var container = try? decoder.unkeyedContainer() {
+            var array = [JSON]()
+            if let count = container.count {
+                for _ in 0..<count {
+                    array.append(try container.decodeIfPresent(JSON.self) ?? .null)
+                }
+            }
+            self = .array(array)
+        } else if let container = try? decoder.container(keyedBy: CodingKeys.self) {
+            var object = [String: JSON]()
+            for key in container.allKeys {
+                object[key.stringValue]
+                    = try container.decodeIfPresent(JSON.self,
+                                                    forKey: key) ?? .null
+            }
+            self = .object(object)
+        } else {
+            self = .invalid
+        }
+    }
+
+    struct CodingKeys: CodingKey {
+
+        var stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+
+        var intValue: Int? { return nil }
+        init?(intValue: Int) { return nil }
+
+    }
+
+}
+
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
     switch (lhs, rhs) {
     case (.null, .null):
@@ -227,8 +273,6 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
         return false
     }
 }
-
-
 
 extension JSON: ExpressibleByStringLiteral,
     ExpressibleByIntegerLiteral,

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -203,52 +203,6 @@ public enum JSON : Equatable, CustomStringConvertible {
     
 }
 
-extension JSON: Decodable {
-
-    public init(from decoder: Decoder) throws {
-        if let container = try? decoder.singleValueContainer() {
-            if let string = try? container.decode(String.self) {
-                self = .string(string)
-            } else if let bool = try? container.decode(Bool.self) {
-                self = .bool(bool)
-            } else if let number = try? container.decode(Double.self) {
-                self = .number(number)
-            } else {
-                self = .invalid
-            }
-        } else if var container = try? decoder.unkeyedContainer() {
-            var array = [JSON]()
-            if let count = container.count {
-                for _ in 0..<count {
-                    array.append(try container.decodeIfPresent(JSON.self) ?? .null)
-                }
-            }
-            self = .array(array)
-        } else if let container = try? decoder.container(keyedBy: CodingKeys.self) {
-            var object = [String: JSON]()
-            for key in container.allKeys {
-                object[key.stringValue]
-                    = try container.decodeIfPresent(JSON.self,
-                                                    forKey: key) ?? .null
-            }
-            self = .object(object)
-        } else {
-            self = .invalid
-        }
-    }
-
-    struct CodingKeys: CodingKey {
-
-        var stringValue: String
-        init?(stringValue: String) { self.stringValue = stringValue }
-
-        var intValue: Int? { return nil }
-        init?(intValue: Int) { return nil }
-
-    }
-
-}
-
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
     switch (lhs, rhs) {
     case (.null, .null):
@@ -273,6 +227,8 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
         return false
     }
 }
+
+
 
 extension JSON: ExpressibleByStringLiteral,
     ExpressibleByIntegerLiteral,

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -65,6 +65,31 @@ public class Swifter {
     public typealias JSONSuccessHandler = (JSON, _ response: HTTPURLResponse) -> Void
     public typealias FailureHandler = (_ error: Error) -> Void
 
+    public struct RawSuccessHandler {
+        private let handler: (Data, FailureHandler?) -> Void
+
+        // getting raw data
+        public init(handler: @escaping (Data) -> Void) {
+            self.handler = { data, _ in handler(data) }
+        }
+
+        // decoding raw data to a given type
+        public init<Entity: Decodable>(decoding type: Entity.Type, handler: @escaping (Entity) -> Void) {
+            self.handler = { data, failure in
+                DispatchQueue.global(qos: .utility).async {
+                    do {
+                        let decodedResponse = try Swifter.decoder.decode(Entity.self, from: data)
+                        DispatchQueue.main.async { handler(decodedResponse) }
+                    } catch {
+                        DispatchQueue.main.async { failure?(error) }
+                    }
+                }
+            }
+        }
+
+        fileprivate func execute(on data: Data, failure: FailureHandler?) { handler(data, failure) }
+    }
+
     internal struct CallbackNotification {
         static let optionsURLKey = "SwifterCallbackNotificationOptionsURLKey"
     }
@@ -73,6 +98,20 @@ public class Swifter {
         static let dataKey = "SwifterDataParameterKey"
         static let fileNameKey = "SwifterDataParameterFilename"
     }
+
+    // MARK: - Static Properties
+
+    internal static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "eee MMM dd HH:mm:ss ZZZZ yyyy"
+        dateFormatter.locale = Locale(identifier: "en_US")
+
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+
+        return decoder
+    }()
 
     // MARK: - Properties
     
@@ -103,39 +142,42 @@ public class Swifter {
     // MARK: - JSON Requests
     
     @discardableResult
-    internal func jsonRequest(path: String, baseURL: TwitterURL, method: HTTPMethodType, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) -> HTTPRequest {
+    internal func jsonRequest(path: String, baseURL: TwitterURL, method: HTTPMethodType, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, rawDownloadProgress: RawSuccessHandler? = nil, success: JSONSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) -> HTTPRequest {
         let jsonDownloadProgressHandler: HTTPRequest.DownloadProgressHandler = { data, _, _, response in
+            if let downloadProgress = downloadProgress {
+                guard let jsonResult = try? JSON.parse(jsonData: data) else {
+                    let jsonString = String(data: data, encoding: .utf8)
+                    let jsonChunks = jsonString!.components(separatedBy: "\r\n")
 
-            guard let _ = downloadProgress else { return }
-            
-            guard let jsonResult = try? JSON.parse(jsonData: data) else {
-                let jsonString = String(data: data, encoding: .utf8)
-                let jsonChunks = jsonString!.components(separatedBy: "\r\n")
-                
-                for chunk in jsonChunks where !chunk.utf16.isEmpty {
-                    guard let chunkData = chunk.data(using: .utf8), let jsonResult = try? JSON.parse(jsonData: chunkData) else { continue }
-                    downloadProgress?(jsonResult, response)
+                    for chunk in jsonChunks where !chunk.utf16.isEmpty {
+                        guard let chunkData = chunk.data(using: .utf8), let jsonResult = try? JSON.parse(jsonData: chunkData) else { continue }
+                        downloadProgress(jsonResult, response)
+                    }
+                    return
                 }
-                return
+
+                downloadProgress(jsonResult, response)
             }
-            
-            downloadProgress?(jsonResult, response)
+
+            rawDownloadProgress?.execute(on: data, failure: failure)
         }
 
         let jsonSuccessHandler: HTTPRequest.SuccessHandler = { data, response in
-
-            DispatchQueue.global(qos: .utility).async {
-                do {
-                    let jsonResult = try JSON.parse(jsonData: data)
-                    DispatchQueue.main.async {
-                        success?(jsonResult, response)
-                    }
-                } catch {
-                    DispatchQueue.main.async {
-                        failure?(error)
+            if let success = success {
+                DispatchQueue.global(qos: .utility).async {
+                    do {
+                        let jsonResult = try JSON.parse(jsonData: data)
+                        DispatchQueue.main.async {
+                            success(jsonResult, response)
+                        }
+                    } catch {
+                        DispatchQueue.main.async {
+                            failure?(error)
+                        }
                     }
                 }
             }
+            rawSuccess?.execute(on: data, failure: failure)
         }
 
         if method == .GET {
@@ -146,13 +188,13 @@ public class Swifter {
     }
 
     @discardableResult
-    internal func getJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
-        return self.jsonRequest(path: path, baseURL: baseURL, method: .GET, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, success: success, failure: failure)
+    internal func getJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, rawDownloadProgress: RawSuccessHandler? = nil, success: JSONSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+        return self.jsonRequest(path: path, baseURL: baseURL, method: .GET, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, rawDownloadProgress: rawDownloadProgress, success: success, rawSuccess: rawSuccess, failure: failure)
     }
 
     @discardableResult
-    internal func postJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, success: JSONSuccessHandler?, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
-        return self.jsonRequest(path: path, baseURL: baseURL, method: .POST, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, success: success, failure: failure)
+    internal func postJSON(path: String, baseURL: TwitterURL, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, rawDownloadProgress: RawSuccessHandler? = nil, success: JSONSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: HTTPRequest.FailureHandler?) -> HTTPRequest {
+        return self.jsonRequest(path: path, baseURL: baseURL, method: .POST, parameters: parameters, uploadProgress: uploadProgress, downloadProgress: downloadProgress, rawDownloadProgress: rawDownloadProgress, success: success, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -164,9 +164,8 @@ public class Swifter {
 
         let jsonSuccessHandler: HTTPRequest.SuccessHandler = { data, response in
             if let success = success {
-                RawSuccessHandler(decoding: JSON.self) { json in
-                    success(json, response)
-                }.execute(on: data, failure: failure)
+                RawSuccessHandler(decoding: JSON.self) { json in success(json, response) }
+                    .execute(on: data, failure: failure)
             }
             rawSuccess?.execute(on: data, failure: failure)
         }

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -108,7 +108,7 @@ public class Swifter {
 
     // MARK: - Static Properties
 
-    internal static let decoder: JSONDecoder = {
+    public static let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
 
         let dateFormatter = DateFormatter()

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -145,18 +145,18 @@ public class Swifter {
     internal func jsonRequest(path: String, baseURL: TwitterURL, method: HTTPMethodType, parameters: Dictionary<String, Any>, uploadProgress: HTTPRequest.UploadProgressHandler? = nil, downloadProgress: JSONSuccessHandler? = nil, rawDownloadProgress: RawSuccessHandler? = nil, success: JSONSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) -> HTTPRequest {
         let jsonDownloadProgressHandler: HTTPRequest.DownloadProgressHandler = { data, _, _, response in
             if let downloadProgress = downloadProgress {
-                guard let jsonResult = try? JSON.parse(jsonData: data) else {
-                    let jsonString = String(data: data, encoding: .utf8)
-                    let jsonChunks = jsonString!.components(separatedBy: "\r\n")
+                RawSuccessHandler(decoding: JSON.self) { json in downloadProgress(json, response) }
+                    .execute(on: data, failure: { _ in
+                        let jsonString = String(data: data, encoding: .utf8)
+                        let jsonChunks = jsonString!.components(separatedBy: "\r\n")
 
-                    for chunk in jsonChunks where !chunk.utf16.isEmpty {
-                        guard let chunkData = chunk.data(using: .utf8), let jsonResult = try? JSON.parse(jsonData: chunkData) else { continue }
-                        downloadProgress(jsonResult, response)
-                    }
-                    return
-                }
-
-                downloadProgress(jsonResult, response)
+                        for chunk in jsonChunks where !chunk.utf16.isEmpty {
+                            guard let chunkData = chunk.data(using: .utf8) else { continue }
+                            RawSuccessHandler(decoding: JSON.self) { json in
+                                downloadProgress(json, response)
+                            }.execute(on: chunkData, failure: failure)
+                        }
+                    })
             }
 
             rawDownloadProgress?.execute(on: data, failure: failure)
@@ -164,18 +164,9 @@ public class Swifter {
 
         let jsonSuccessHandler: HTTPRequest.SuccessHandler = { data, response in
             if let success = success {
-                DispatchQueue.global(qos: .utility).async {
-                    do {
-                        let jsonResult = try JSON.parse(jsonData: data)
-                        DispatchQueue.main.async {
-                            success(jsonResult, response)
-                        }
-                    } catch {
-                        DispatchQueue.main.async {
-                            failure?(error)
-                        }
-                    }
-                }
+                RawSuccessHandler(decoding: JSON.self) { json in
+                    success(json, response)
+                }.execute(on: data, failure: failure)
             }
             rawSuccess?.execute(on: data, failure: failure)
         }

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -170,12 +170,12 @@ public class Swifter {
         }
 
         let jsonSuccessHandler: HTTPRequest.SuccessHandler = { data, response in
-            if let success = success {
+            if success != nil || failure != nil {
                 DispatchQueue.global(qos: .utility).async {
                     do {
                         let jsonResult = try JSON.parse(jsonData: data)
                         DispatchQueue.main.async {
-                            success(jsonResult, response)
+                            success?(jsonResult, response)
                         }
                     } catch {
                         DispatchQueue.main.async {

--- a/Sources/SwifterFavorites.swift
+++ b/Sources/SwifterFavorites.swift
@@ -34,7 +34,7 @@ public extension Swifter {
 
     If you do not provide either a user_id or screen_name to this method, it will assume you are requesting on behalf of the authenticating user. Specify one or the other for best results.
     */
-    public func getRecentlyFavouritedTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRecentlyFavouritedTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -42,10 +42,10 @@ public extension Swifter {
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
-    public func getRecentlyFavouritedTweets(for userTag: UserTag, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRecentlyFavouritedTweets(for userTag: UserTag, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/list.json"
         
         var parameters = Dictionary<String, Any>()
@@ -54,7 +54,7 @@ public extension Swifter {
         parameters["since_id"] ??= sinceID
         parameters["max_id"] ??= maxID
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -64,14 +64,14 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func unfavouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unfavouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "favorites/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -81,14 +81,14 @@ public extension Swifter {
 
     This process invoked by this method is asynchronous. The immediately returned status may not indicate the resultant favorited status of the tweet. A 200 OK response from this method will indicate whether the intended action was successful or not.
     */
-    public func favouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) {
+    public func favouriteTweet(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: HTTPRequest.FailureHandler? = nil) {
         let path = "favorites/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterFollowers.swift
+++ b/Sources/SwifterFollowers.swift
@@ -32,13 +32,13 @@ public extension Swifter {
 
     Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from. Use POST friendships/update to set the "no retweets" status for a given user account on behalf of the current user.
     */
-    public func listOfNoRetweetsFriends(stringifyIDs: Bool = true, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func listOfNoRetweetsFriends(stringifyIDs: Bool = true, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/no_retweets/ids.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["stringify_ids"] = stringifyIDs
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -51,7 +51,7 @@ public extension Swifter {
 
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getUserFollowingIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowingIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friends/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -62,7 +62,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -74,7 +74,7 @@ public extension Swifter {
     
     This method is especially powerful when used in conjunction with GET users/lookup, a method that allows you to convert user IDs into full user objects in bulk.
     */
-    public func getUserFollowersIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowersIDs(for userTag: UserTag, cursor: String? = nil, stringifyIDs: Bool? = nil, count: Int? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "followers/ids.json"
         
         var parameters = Dictionary<String, Any>()
@@ -85,7 +85,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -93,7 +93,7 @@ public extension Swifter {
     
     Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
     */
-    public func getIncomingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getIncomingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/incoming.json"
         
         var parameters = Dictionary<String, Any>()
@@ -102,7 +102,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -110,7 +110,7 @@ public extension Swifter {
     
     Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
     */
-    public func getOutgoingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getOutgoingPendingFollowRequests(cursor: String? = nil, stringifyIDs: String? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/outgoing.json"
         
         var parameters = Dictionary<String, Any>()
@@ -119,7 +119,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -131,7 +131,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func followUser(for userTag: UserTag, follow: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func followUser(for userTag: UserTag, follow: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -140,7 +140,7 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -152,7 +152,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func unfollowUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unfollowUser(for userTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -160,7 +160,7 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -168,7 +168,7 @@ public extension Swifter {
 
     Allows one to enable or disable retweets and device notifications from the specified user.
     */
-    public func updateFriendship(with userTag: UserTag, device: Bool? = nil, retweets: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateFriendship(with userTag: UserTag, device: Bool? = nil, retweets: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -178,7 +178,7 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -186,7 +186,7 @@ public extension Swifter {
 
     Returns detailed information about the relationship between two arbitrary users.
     */
-    public func showFriendship(between sourceTag: UserTag, and targetTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showFriendship(between sourceTag: UserTag, and targetTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friendships/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -202,7 +202,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -212,7 +212,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getUserFollowing(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowing(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "friends/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -224,7 +224,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -234,7 +234,7 @@ public extension Swifter {
 
     At this time, results are ordered with the most recent following first — however, this ordering is subject to unannounced change and eventual consistency issues. Results are given in groups of 20 users and multiple "pages" of results can be navigated through using the next_cursor value in subsequent requests. See Using cursors to navigate collections for more information.
     */
-    public func getUserFollowers(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserFollowers(for userTag: UserTag, cursor: String? = nil, count: Int? = nil, skipStatus: Bool? = nil, includeUserEntities: Bool? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "followers/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -246,7 +246,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -254,7 +254,7 @@ public extension Swifter {
 
     Returns the relationships of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids provided. Values for connections can be: following, following_requested, followed_by, none.
     */
-    public func lookupFriendship(with usersTag: UsersTag, success: SuccessHandler? = nil, failure: FailureHandler?) {
+    public func lookupFriendship(with usersTag: UsersTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "friendships/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -262,7 +262,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterHelp.swift
+++ b/Sources/SwifterHelp.swift
@@ -34,10 +34,10 @@ public extension Swifter {
 
     It is recommended applications request this endpoint when they are loaded, but no more than once a day.
     */
-    public func getHelpConfiguration(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getHelpConfiguration(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/configuration.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -45,10 +45,10 @@ public extension Swifter {
 
     Returns the list of languages supported by Twitter along with their ISO 639-1 code. The ISO 639-1 code is the two letter value to use if you include lang with any of your requests.
     */
-    public func getHelpLanguages(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getHelpLanguages(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/languages.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -56,10 +56,10 @@ public extension Swifter {
 
     Returns Twitter's Privacy Policy.
     */
-    public func getHelpPrivacy(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getHelpPrivacy(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/privacy.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["privacy"]) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["privacy"]) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -67,10 +67,10 @@ public extension Swifter {
 
     Returns the Twitter Terms of Service in the requested format. These are not the same as the Developer Rules of the Road.
     */
-    public func getHelpTermsOfService(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getHelpTermsOfService(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "help/tos.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["tos"]) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json["tos"]) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -88,13 +88,13 @@ public extension Swifter {
 
     Read more about REST API Rate Limiting in v1.1 and review the limits.
     */
-    public func getRateLimits(for resources: [String], success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRateLimits(for resources: [String], success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "application/rate_limit_status.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["resources"] = resources.joined(separator: ",")
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterLists.swift
+++ b/Sources/SwifterLists.swift
@@ -36,7 +36,7 @@ public extension Swifter {
 
     A maximum of 100 results will be returned by this call. Subscribed lists are returned first, followed by owned lists. This means that if a user subscribes to 90 lists and owns 20 lists, this method returns 90 subscriptions and 10 owned lists. The reverse method returns owned lists first, so with reverse=true, 20 owned lists and 80 subscriptions would be returned. If your goal is to obtain every list a user owns or subscribes to, use GET lists/ownerships and/or GET lists/subscriptions instead.
     */
-    public func getSubscribedLists(reverse: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedLists(reverse: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -44,10 +44,10 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
-    public func getSubscribedLists(for userTag: UserTag, reverse: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedLists(for userTag: UserTag, reverse: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -56,7 +56,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -64,7 +64,7 @@ public extension Swifter {
 
     Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets. Embedded Timelines is a great way to embed list timelines on your website.
     */
-    public func listTweets(for listTag: ListTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func listTweets(for listTag: ListTag, sinceID: String?, maxID: String?, count: Int?, includeEntities: Bool?, includeRTs: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/statuses.json"
 
         var parameters = Dictionary<String, Any>()
@@ -78,7 +78,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["include_rts"] ??= includeRTs
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -86,7 +86,7 @@ public extension Swifter {
 
     Removes the specified member from the list. The authenticated user must be the list's owner to remove members from the list.
     */
-    public func removeMemberFromList(for listTag: ListTag, user userTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func removeMemberFromList(for listTag: ListTag, user userTag: UserTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -96,7 +96,7 @@ public extension Swifter {
         }
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -104,7 +104,7 @@ public extension Swifter {
 
     Returns the lists the specified user has been added to. If user_id or screen_name are not provided the memberships for the authenticating user are returned.
     */
-    public func getListMemberships(for userTag: UserTag, count: Int? = nil, cursor: String?, filterToOwnedLists: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListMemberships(for userTag: UserTag, count: Int? = nil, cursor: String?, filterToOwnedLists: Bool?, success: CursorSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/memberships.json"
 
         var parameters = Dictionary<String, Any>()
@@ -115,7 +115,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -123,7 +123,7 @@ public extension Swifter {
 
     Returns the subscribers of the specified list. Private list subscribers will only be shown if the authenticated user owns the specified list.
     */
-    public func getListSubscribers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListSubscribers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/subscribers.json"
 
         var parameters = Dictionary<String, Any>()
@@ -137,7 +137,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -145,7 +145,7 @@ public extension Swifter {
 
     Subscribes the authenticated user to the specified list.
     */
-    public func subscribeToList(for listTag: ListTag, owner ownerTag: UserTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func subscribeToList(for listTag: ListTag, owner ownerTag: UserTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/subscribers/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -154,7 +154,7 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -162,7 +162,7 @@ public extension Swifter {
 
     Check if the specified user is a subscriber of the specified list. Returns the user if they are subscriber.
     */
-    public func checkListSubcription(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func checkListSubcription(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/subscribers/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -174,7 +174,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -182,7 +182,7 @@ public extension Swifter {
 
     Unsubscribes the authenticated user from the specified list.
     */
-    public func unsubscribeFromList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func unsubscribeFromList(for listTag: ListTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/subscribers/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -191,7 +191,7 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -201,7 +201,7 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func subscribeUsersToList(for listTag: ListTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func subscribeUsersToList(for listTag: ListTag, users usersTag: UsersTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members/create_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -214,7 +214,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -222,7 +222,7 @@ public extension Swifter {
 
     Check if the specified user is a member of the specified list.
     */
-    public func checkListMembership(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func checkListMembership(of userTag: UserTag, for listTag: ListTag, includeEntities: Bool?, skipStatus: Bool?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -234,7 +234,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -243,7 +243,7 @@ public extension Swifter {
     Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     */
 
-    public func getListMembers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getListMembers(for listTag: ListTag, cursor: String?, includeEntities: Bool?, skipStatus: Bool?, success: CursorSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members.json"
 
         var parameters = Dictionary<String, Any>()
@@ -257,7 +257,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -265,7 +265,7 @@ public extension Swifter {
 
     Add a member to a list. The authenticated user must own the list to be able to add members to it. Note that lists cannot have more than 5,000 members.
     */
-    public func addListMember(_ userTag: UserTag, for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func addListMember(_ userTag: UserTag, for listTag: ListTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -275,7 +275,7 @@ public extension Swifter {
         }
         parameters[userTag.key] = userTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -283,7 +283,7 @@ public extension Swifter {
 
     Deletes the specified list. The authenticated user must own the list to be able to destroy it.
     */
-    public func deleteList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func deleteList(for listTag: ListTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -292,7 +292,7 @@ public extension Swifter {
             parameters[owner.ownerKey] = owner.value
         }
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -300,7 +300,7 @@ public extension Swifter {
 
     Updates the specified list. The authenticated user must own the list to be able to update it.
     */
-    public func updateList(for listTag: ListTag, name: String?, isPublic: Bool = true, description: String?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func updateList(for listTag: ListTag, name: String?, isPublic: Bool = true, description: String?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -312,7 +312,7 @@ public extension Swifter {
         parameters["mode"] = isPublic ? "public" : "private"
         parameters["description"] ??= description
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -320,7 +320,7 @@ public extension Swifter {
 
     Creates a new list for the authenticated user. Note that you can't create more than 20 lists per account.
     */
-    public func createList(named name: String, asPublicList: Bool = true, description: String?, success: SuccessHandler?, failure: FailureHandler?) {
+    public func createList(named name: String, asPublicList: Bool = true, description: String?, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -328,7 +328,7 @@ public extension Swifter {
         parameters["mode"] = asPublicList ? "public" : "private"
         parameters["description"] ??= description
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -336,7 +336,7 @@ public extension Swifter {
 
     Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     */
-    public func showList(for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func showList(for listTag: ListTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -347,7 +347,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -355,7 +355,7 @@ public extension Swifter {
 
     Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default. Does not include the user's own lists.
     */
-    public func getSubscribedList(of userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getSubscribedList(of userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/subscriptions.json"
 
         var parameters = Dictionary<String, Any>()
@@ -365,7 +365,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -375,7 +375,7 @@ public extension Swifter {
 
     Please note that there can be issues with lists that rapidly remove and add memberships. Take care when using these methods such that you are not too rapidly switching between removals and adds on the same list.
     */
-    public func removeListMembers(_ usersTag: UsersTag, for listTag: ListTag, success: SuccessHandler?, failure: FailureHandler?) {
+    public func removeListMembers(_ usersTag: UsersTag, for listTag: ListTag, success: SuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/members/destroy_all.json"
 
         var parameters = Dictionary<String, Any>()
@@ -385,7 +385,7 @@ public extension Swifter {
         }
         parameters[usersTag.key] = usersTag.value
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -393,7 +393,7 @@ public extension Swifter {
     
     Returns the lists owned by the specified Twitter user. Private lists will only be shown if the authenticated user is also the owner of the lists.
     */
-    public func getOwnedLists(for userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, failure: FailureHandler?) {
+    public func getOwnedLists(for userTag: UserTag, count: String?, cursor: String?, success: CursorSuccessHandler?, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
         let path = "lists/ownerships.json"
         
         var parameters = Dictionary<String, Any>()
@@ -403,7 +403,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in            
             success?(json["lists"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
         
     }
     

--- a/Sources/SwifterMessages.swift
+++ b/Sources/SwifterMessages.swift
@@ -32,7 +32,7 @@ public extension Swifter {
 
     Returns the 20 most recent direct messages sent to the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 incoming DMs.
     */
-    public func getDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages.json"
 
         var parameters = Dictionary<String, Any>()
@@ -42,7 +42,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -50,7 +50,7 @@ public extension Swifter {
 
     Returns the 20 most recent direct messages sent by the authenticating user. Includes detailed information about the sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 outgoing DMs.
     */
-    public func getSentDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, page: Int? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSentDirectMessages(since sinceID: String? = nil, maxID: String? = nil, count: Int? = nil, page: Int? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/sent.json"
 
         var parameters = Dictionary<String, Any>()
@@ -60,7 +60,7 @@ public extension Swifter {
         parameters["page"] ??= page
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -68,11 +68,11 @@ public extension Swifter {
 
     Returns a single direct message, specified by an id parameter. Like the /1.1/direct_messages.format request, this method will include the user objects of the sender and recipient.
     */
-    public func showDirectMessage(forID id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showDirectMessage(forID id: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/show.json"
         let parameters: [String: Any] = ["id" : id]
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -80,14 +80,14 @@ public extension Swifter {
 
     Destroys the direct message specified in the required ID parameter. The authenticating user must be the recipient of the specified direct message.
     */
-    public func destroyDirectMessage(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func destroyDirectMessage(forID id: String, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/destroy.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = id
         parameters["include_entities"] ??= includeEntities
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -95,14 +95,14 @@ public extension Swifter {
 
     Sends a new direct message to the specified user from the authenticating user. Requires both the user and text parameters and must be a POST. Returns the sent message in the requested format if successful.
     */
-    public func sendDirectMessage(to userTag: UserTag, text: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func sendDirectMessage(to userTag: UserTag, text: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "direct_messages/new.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["text"] = text
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterPlaces.swift
+++ b/Sources/SwifterPlaces.swift
@@ -32,10 +32,10 @@ public extension Swifter {
 
     Returns all the information about a known place.
     */
-    public func getGeoID(for placeID: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getGeoID(for placeID: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "geo/id/\(placeID).json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -45,7 +45,7 @@ public extension Swifter {
 
     This request is an informative call and will deliver generalized results about geography.
     */
-    public func getReverseGeocode(for coordinate: (lat: Double, long: Double), accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getReverseGeocode(for coordinate: (lat: Double, long: Double), accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, callback: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "geo/reverse_geocode.json"
 
         var parameters = Dictionary<String, Any>()
@@ -57,7 +57,7 @@ public extension Swifter {
         parameters["max_results"] ??= maxResults
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -69,7 +69,7 @@ public extension Swifter {
 
     This is the recommended method to use find places that can be attached to statuses/update. Unlike GET geo/reverse_geocode which provides raw data access, this endpoint can potentially re-order places with regards to the user who is authenticated. This approach is also preferred for interactive place matching with the user.
     */
-    public func searchGeo(coordinate: (lat: Double, long: Double)? = nil, query: String? = nil, ipAddress: String? = nil, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func searchGeo(coordinate: (lat: Double, long: Double)? = nil, query: String? = nil, ipAddress: String? = nil, accuracy: String? = nil, granularity: String? = nil, maxResults: Int? = nil, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(coordinate != nil || query != nil || ipAddress != nil, "At least one of the following parameters must be provided to access this resource: coordinate, ipAddress, or query")
 
         let path = "geo/search.json"
@@ -90,7 +90,7 @@ public extension Swifter {
         parameters["attribute:street_address"] ??= attributeStreetAddress
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -102,7 +102,7 @@ public extension Swifter {
 
     The token contained in the response is the token needed to be able to create a new place.
     */
-    public func getSimilarPlaces(for coordinate: (lat: Double, long: Double), name: String, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSimilarPlaces(for coordinate: (lat: Double, long: Double), name: String, containedWithin: String? = nil, attributeStreetAddress: String? = nil, callback: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "geo/similar_places.json"
 
         var parameters = Dictionary<String, Any>()
@@ -114,7 +114,7 @@ public extension Swifter {
         parameters["attribute:street_address"] ??= attributeStreetAddress
         parameters["callback"] ??= callback
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterSavedSearches.swift
+++ b/Sources/SwifterSavedSearches.swift
@@ -32,10 +32,10 @@ public extension Swifter {
 
     Returns the authenticated user's saved search queries.
     */
-    public func getSavedSearchesList(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getSavedSearchesList(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/list.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -43,10 +43,10 @@ public extension Swifter {
 
     Retrieve the information for the saved search represented by the given id. The authenticating user must be the owner of saved search ID being requested.
     */
-    public func showSavedSearch(for id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func showSavedSearch(for id: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/show/\(id).json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -54,13 +54,13 @@ public extension Swifter {
 
     Create a new saved search for the authenticated user. A user may only have 25 saved searches.
     */
-    public func createSavedSearch(for query: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func createSavedSearch(for query: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/create.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["query"] = query
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -68,10 +68,10 @@ public extension Swifter {
 
     Destroys a saved search for the authenticating user. The authenticating user must be the owner of saved search id being destroyed.
     */
-    public func deleteSavedSearch(for id: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func deleteSavedSearch(for id: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "saved_searches/destroy/\(id).json"
 
-        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterSearch.swift
+++ b/Sources/SwifterSearch.swift
@@ -37,7 +37,7 @@ public extension Swifter {
      In API v1.1, the response format of the Search API has been improved to return Tweet objects more similar to the objects you’ll find across the REST API and platform. However, perspectival attributes (fields that pertain to the perspective of the authenticating user) are not currently supported on this endpoint.
 
      */
-    public func searchTweet(using query: String, geocode: String? = nil, lang: String? = nil, locale: String? = nil, resultType: String? = nil, count: Int? = nil, until: String? = nil, sinceID: String? = nil, maxID: String? = nil, includeEntities: Bool? = nil, callback: String? = nil, success: ((JSON, _ searchMetadata: JSON) -> Void)? = nil, failure: @escaping FailureHandler) {
+    public func searchTweet(using query: String, geocode: String? = nil, lang: String? = nil, locale: String? = nil, resultType: String? = nil, count: Int? = nil, until: String? = nil, sinceID: String? = nil, maxID: String? = nil, includeEntities: Bool? = nil, callback: String? = nil, success: ((JSON, _ searchMetadata: JSON) -> Void)? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "search/tweets.json"
 
         var parameters = Dictionary<String, Any>()
@@ -55,7 +55,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["statuses"], json["search_metadata"])
-            }, failure: failure)
+        }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterSpam.swift
+++ b/Sources/SwifterSpam.swift
@@ -32,13 +32,13 @@ public extension Swifter {
 
     Report the specified user as a spam account to Twitter. Additionally performs the equivalent of POST blocks/create on behalf of the authenticated user.
     */
-    public func reportSpam(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func reportSpam(for userTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "users/report_spam.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterStreaming.swift
+++ b/Sources/SwifterStreaming.swift
@@ -40,7 +40,7 @@ public extension Swifter {
 
     At least one predicate parameter (follow, locations, or track) must be specified.
     */
-    public func postTweetFilters(follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func postTweetFilters(follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         
         assert(follow != nil || track != nil || locations != nil, "At least one predicate parameter (follow, locations, or track) must be specified")
 
@@ -61,8 +61,7 @@ public extension Swifter {
             } else {
                 progress?(json)
             }
-
-            }, success: { json, _ in progress?(json) }, failure: failure)
+        }, rawDownloadProgress: rawProgress, success: { json, _ in progress?(json) }, rawSuccess: rawProgress, failure: failure)
     }
 
     /**
@@ -70,7 +69,7 @@ public extension Swifter {
 
     Returns a small random sample of all public statuses. The Tweets returned by the default access level are the same, so if two different clients connect to this endpoint, they will see the same Tweets.
     */
-    public func streamRandomSampleTweets(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamRandomSampleTweets(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/sample.json"
 
         var parameters = Dictionary<String, Any>()
@@ -86,7 +85,7 @@ public extension Swifter {
                 progress?(json)
             }
 
-            }, success: { json, _ in progress?(json) }, failure: failure)
+            }, rawDownloadProgress: rawProgress, success: { json, _ in progress?(json) }, rawSuccess: rawProgress, failure: failure)
     }
 
     /**
@@ -97,7 +96,7 @@ public extension Swifter {
     Returns all public statuses. Few applications require this level of access. Creative use of a combination of other resources and various access levels can satisfy nearly every application use case.
     */
     
-    public func streamFirehoseTweets(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamFirehoseTweets(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/firehose.json"
 
         var parameters = Dictionary<String, Any>()
@@ -113,8 +112,7 @@ public extension Swifter {
             } else {
                 progress?(json)
             }
-
-            }, success: { json, _ in progress?(json) }, failure: failure)
+        }, rawDownloadProgress: rawProgress, success: { json, _ in progress?(json) }, rawSuccess: rawProgress, failure: failure)
     }
 
     /**
@@ -122,7 +120,7 @@ public extension Swifter {
 
     Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func beginUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
@@ -147,7 +145,7 @@ public extension Swifter {
                 progress?(json)
             }
 
-            }, success: { json, _ in progress?(json) }, failure: failure)
+            }, rawDownloadProgress: rawProgress, success: { json, _ in progress?(json) }, rawSuccess: rawProgress, failure: failure)
     }
 
     /**
@@ -155,7 +153,7 @@ public extension Swifter {
 
     Streams messages for a set of users, as described in Site streams https://dev.twitter.com/docs/streaming-apis/streams/site
     */
-    public func beginSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "site.json"
 
         var parameters = Dictionary<String, Any>()
@@ -171,7 +169,7 @@ public extension Swifter {
 
         return self.getJSON(path: path, baseURL: .stream, parameters: parameters, downloadProgress: { json, _ in
             stallWarningHandler?(json["warning"]["code"].string, json["warning"]["message"].string, json["warning"]["percent_full"].integer)
-            }, success: { json, _ in progress?(json) }, failure: failure)
+            }, rawDownloadProgress: rawProgress, success: { json, _ in progress?(json) }, rawSuccess: rawProgress, failure: failure)
     }
     
 }

--- a/Sources/SwifterStreaming.swift
+++ b/Sources/SwifterStreaming.swift
@@ -40,7 +40,7 @@ public extension Swifter {
 
     At least one predicate parameter (follow, locations, or track) must be specified.
     */
-    public func postTweetFilters(follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func postTweetFilters(follow: [String]? = nil, track: [String]? = nil, locations: [String]? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, rawProgress: RawSuccessHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         
         assert(follow != nil || track != nil || locations != nil, "At least one predicate parameter (follow, locations, or track) must be specified")
 
@@ -69,7 +69,7 @@ public extension Swifter {
 
     Returns a small random sample of all public statuses. The Tweets returned by the default access level are the same, so if two different clients connect to this endpoint, they will see the same Tweets.
     */
-    public func streamRandomSampleTweets(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamRandomSampleTweets(delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, rawProgress: RawSuccessHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/sample.json"
 
         var parameters = Dictionary<String, Any>()
@@ -96,7 +96,7 @@ public extension Swifter {
     Returns all public statuses. Few applications require this level of access. Creative use of a combination of other resources and various access levels can satisfy nearly every application use case.
     */
     
-    public func streamFirehoseTweets(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func streamFirehoseTweets(count: Int? = nil, delimited: Bool? = nil, stallWarnings: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, rawProgress: RawSuccessHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "statuses/firehose.json"
 
         var parameters = Dictionary<String, Any>()
@@ -120,7 +120,7 @@ public extension Swifter {
 
     Streams messages for a single user, as described in User streams https://dev.twitter.com/docs/streaming-apis/streams/user
     */
-    public func beginUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginUserStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, includeMessagesFromUserOnly: Bool = false, includeReplies: Bool = false, track: [String]? = nil, locations: [String]? = nil, stringifyFriendIDs: Bool? = nil, filter_level: String? = nil, language: [String]? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, rawProgress: RawSuccessHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "user.json"
 
         var parameters = Dictionary<String, Any>()
@@ -153,7 +153,7 @@ public extension Swifter {
 
     Streams messages for a set of users, as described in Site streams https://dev.twitter.com/docs/streaming-apis/streams/site
     */
-    public func beginSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: SuccessHandler? = nil, rawProgress: RawSuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
+    public func beginSiteStream(delimited: Bool? = nil, stallWarnings: Bool? = nil, restrictToUserMessages: Bool = false, includeReplies: Bool = false, stringifyFriendIDs: Bool? = nil, progress: SuccessHandler? = nil, stallWarningHandler: StallWarningHandler? = nil, rawProgress: RawSuccessHandler? = nil, failure: FailureHandler? = nil) -> HTTPRequest {
         let path = "site.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Sources/SwifterSuggested.swift
+++ b/Sources/SwifterSuggested.swift
@@ -34,13 +34,13 @@ public extension Swifter {
 
     It is recommended that applications cache this data for no more than one hour.
     */
-    public func getUserSuggestions(slug: String, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUserSuggestions(slug: String, lang: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions/\(slug).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -48,13 +48,13 @@ public extension Swifter {
 
     Access to Twitter's suggested user list. This returns the list of suggested user categories. The category can be used in GET users/suggestions/:slug to get the users in that category.
     */
-    public func getUsersSuggestions(lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(lang: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -62,9 +62,9 @@ public extension Swifter {
 
     Access the users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user.
     */
-    public func getUsersSuggestions(for slug: String, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getUsersSuggestions(for slug: String, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "users/suggestions/\(slug)/members.json"
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterTimelines.swift
+++ b/Sources/SwifterTimelines.swift
@@ -28,7 +28,7 @@ import Foundation
 public extension Swifter {
 
     // Convenience method
-    private func getTimeline(at path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    private func getTimeline(at path: String, parameters: Dictionary<String, Any>, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         var params = parameters
         params["count"] ??= count
         params["since_id"] ??= sinceID
@@ -39,7 +39,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: params, success: { json, _ in
             success?(json)
-            }, failure: failure)
+        }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -52,8 +52,8 @@ public extension Swifter {
 
     This method can only return up to 800 tweets.
     */
-    public func getMentionsTimelineTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler?) {
-        self.getTimeline(at: "statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getMentionsTimelineTweets(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler?) {
+        self.getTimeline(at: "statuses/mentions_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, rawSuccess: rawSuccess, failure: failure)
     }
 
 
@@ -69,10 +69,10 @@ public extension Swifter {
 
     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
     */
-    public func getTimeline(for userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTimeline(for userID: String, count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let parameters: Dictionary<String, Any> = ["user_id": userID]
 
-        self.getTimeline(at: "statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+        self.getTimeline(at: "statuses/user_timeline.json", parameters: parameters, count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -84,8 +84,8 @@ public extension Swifter {
 
     Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow many users or follow users who tweet frequently.
     */
-    public func getHomeTimeline(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        self.getTimeline(at: "statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getHomeTimeline(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
+        self.getTimeline(at: "statuses/home_timeline.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -93,8 +93,8 @@ public extension Swifter {
 
     Returns the most recent tweets authored by the authenticating user that have been retweeted by others. This timeline is a subset of the user's GET statuses/user_timeline. See Working with Timelines for instructions on traversing timelines.
     */
-    public func getRetweetsOfMe(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
-        self.getTimeline(at: "statuses/retweets_of_me.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, failure: failure)
+    public func getRetweetsOfMe(count: Int? = nil, sinceID: String? = nil, maxID: String? = nil, trimUser: Bool? = nil, contributorDetails: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
+        self.getTimeline(at: "statuses/retweets_of_me.json", parameters: [:], count: count, sinceID: sinceID, maxID: maxID, trimUser: trimUser, contributorDetails: contributorDetails, includeEntities: includeEntities, success: success, rawSuccess: rawSuccess, failure: failure)
     }
 
 }

--- a/Sources/SwifterTrends.swift
+++ b/Sources/SwifterTrends.swift
@@ -19,14 +19,14 @@ public extension Swifter {
 
     This information is cached for 5 minutes. Requesting more frequently than that will not return any more data, and will count against your rate limit usage.
     */
-    public func getTrendsPlace(with woeid: String, excludeHashtags: Bool = false, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTrendsPlace(with woeid: String, excludeHashtags: Bool = false, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "trends/place.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["id"] = woeid
         parameters["exclude"] = excludeHashtags ? "hashtags" : nil
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -38,9 +38,9 @@ public extension Swifter {
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getAvailableTrends(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getAvailableTrends(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "trends/available.json"
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -52,13 +52,13 @@ public extension Swifter {
 
     A WOEID is a Yahoo! Where On Earth ID.
     */
-    public func getClosestTrends(for coordinate: (lat: Double, long: Double), success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getClosestTrends(for coordinate: (lat: Double, long: Double), success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "trends/closest.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["lat"] = coordinate.lat
         parameters["long"] = coordinate.long
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
 }

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -140,7 +140,7 @@ public extension Swifter {
         }, rawSuccess: rawSuccess, failure: failure)
     }
 
-    public func postTweet(status: String, media: Data, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, tweetMode: TweetMode = TweetMode.default, success: SuccessHandler? = nil, success: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postTweet(status: String, media: Data, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, tweetMode: TweetMode = TweetMode.default, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path: String = "statuses/update_with_media.json"
 
         var parameters = Dictionary<String, Any>()

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -32,13 +32,13 @@ public extension Swifter {
 
     Returns up to 100 of the first retweets of a given tweet.
     */
-    public func getRetweets(forTweetID id: String, count: Int? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getRetweets(forTweetID id: String, count: Int? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweets/\(id).json"
         var parameters = Dictionary<String, Any>()
         parameters["count"] ??= count
         parameters["trim_user"] ??= trimUser
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -60,7 +60,7 @@ public extension Swifter {
 
     This object contains an array of user IDs for users who have contributed to this status (an example of a status that has been contributed to is this one). In practice, there is usually only one ID in this array. The JSON renders as such "contributors":[8285392].
     */
-    public func getTweet(forID id: String, count: Int? = nil, trimUser: Bool? = nil, includeMyRetweet: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getTweet(forID id: String, count: Int? = nil, trimUser: Bool? = nil, includeMyRetweet: Bool? = nil, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/show.json"
 
         var parameters = Dictionary<String, Any>()
@@ -70,7 +70,7 @@ public extension Swifter {
         parameters["include_my_retweet"] ??= includeMyRetweet
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -78,13 +78,13 @@ public extension Swifter {
 
     Destroys the status specified by the required ID parameter. The authenticating user must be the author of the specified status. Returns the destroyed status if successful.
     */
-    public func destroyTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func destroyTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/destroy/\(id).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -109,7 +109,7 @@ public extension Swifter {
     - https://dev.twitter.com/notifications/multiple-media-entities-in-tweets
     - https://dev.twitter.com/docs/api/multiple-media-extended-entities
     */
-    public func postTweet(status: String, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, media_ids: [String] = [], success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postTweet(status: String, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, media_ids: [String] = [], success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path: String = "statuses/update.json"
 
         var parameters = Dictionary<String, Any>()
@@ -132,10 +132,10 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
-    public func postTweet(status: String, media: Data, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postTweet(status: String, media: Data, inReplyToStatusID: String? = nil, coordinate: (lat: Double, long: Double)? = nil, placeID: Double? = nil, displayCoordinates: Bool? = nil, trimUser: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path: String = "statuses/update_with_media.json"
 
         var parameters = Dictionary<String, Any>()
@@ -156,7 +156,7 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -169,14 +169,14 @@ public extension Swifter {
     - https://dev.twitter.com/rest/public/uploading-media
     - https://dev.twitter.com/rest/reference/post/media/upload
     */
-    public func postMedia(_ media: Data, additionalOwners: UsersTag? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func postMedia(_ media: Data, additionalOwners: UsersTag? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path: String = "media/upload.json"
         var parameters = Dictionary<String, Any>()
         parameters["media"] = media
         parameters["additional_owers"] ??= additionalOwners?.value
         parameters[Swifter.DataParameters.dataKey] = "media"
 
-        self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -190,13 +190,13 @@ public extension Swifter {
 
     Returns Tweets (1: the new tweet)
     */
-    public func retweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func retweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweet/\(id).json"
 
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -211,13 +211,13 @@ public extension Swifter {
      
      Returns Tweets (1: the original tweet)
      */
-    public func unretweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unretweetTweet(forID id: String, trimUser: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/unretweet/\(id).json"
         
         var parameters = Dictionary<String, Any>()
         parameters["trim_user"] ??= trimUser
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -227,7 +227,7 @@ public extension Swifter {
 
     While this endpoint allows a bit of customization for the final appearance of the embedded Tweet, be aware that the appearance of the rendered Tweet may change over time to be consistent with Twitter's Display Requirements. Do not rely on any class or id parameters to stay constant in the returned markup.
     */
-    public func oembedInfo(forID id: String, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func oembedInfo(forID id: String, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -240,10 +240,10 @@ public extension Swifter {
         parameters["related"] ??= related
         parameters["lang"] ??= lang
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
-    public func oembedInfo(forUrl url: URL, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func oembedInfo(forUrl url: URL, maxWidth: Int? = nil, hideMedia: Bool? = nil, hideThread: Bool? = nil, omitScript: Bool? = nil, align: String? = nil, related: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/oembed.json"
 
         var parameters = Dictionary<String, Any>()
@@ -256,7 +256,7 @@ public extension Swifter {
         parameters["related"] ??= related
         parameters["lang"] ??= lang
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -266,7 +266,7 @@ public extension Swifter {
 
     This method offers similar data to GET statuses/retweets/:id and replaces API v1's GET statuses/:id/retweeted_by/ids method.
     */
-    public func tweetRetweeters(forID id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func tweetRetweeters(forID id: String, cursor: String? = nil, stringifyIDs: Bool? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/retweeters/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -276,7 +276,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -284,7 +284,7 @@ public extension Swifter {
 
     Returns fully-hydrated tweet objects for up to 100 tweets per request, as specified by comma-separated values passed to the id parameter. This method is especially useful to get the details (hydrate) a collection of Tweet IDs. GET statuses/show/:id is used to retrieve a single tweet object.
     */
-    public func lookupTweets(for tweetIDs: [String], includeEntities: Bool? = nil, map: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func lookupTweets(for tweetIDs: [String], includeEntities: Bool? = nil, map: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "statuses/lookup.json"
 
         var parameters = Dictionary<String, Any>()
@@ -292,7 +292,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["map"] ??= map
         
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }

--- a/Sources/SwifterUsers.swift
+++ b/Sources/SwifterUsers.swift
@@ -32,10 +32,10 @@ public extension Swifter {
 
     Returns settings (including current trend, geo and sleep time information) for the authenticating user.
     */
-    public func getAccountSettings(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getAccountSettings(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/settings.json"
 
-        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -43,14 +43,14 @@ public extension Swifter {
 
     Returns an HTTP 200 OK response code and a representation of the requesting user if authentication was successful; returns a 401 status code and an error message if not. Use this method to test if supplied user credentials are valid.
     */
-    public func verifyAccountCredentials(includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func verifyAccountCredentials(includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/verify_credentials.json"
 
         var parameters = Dictionary<String, Any>()
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -58,7 +58,7 @@ public extension Swifter {
 
     Updates the authenticating user's settings.
     */
-    public func updateAccountSettings(trendLocationWOEID: String? = nil, sleepTimeEnabled: Bool? = nil, startSleepTime: Int? = nil, endSleepTime: Int? = nil, timeZone: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateAccountSettings(trendLocationWOEID: String? = nil, sleepTimeEnabled: Bool? = nil, startSleepTime: Int? = nil, endSleepTime: Int? = nil, timeZone: String? = nil, lang: String? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(trendLocationWOEID != nil || sleepTimeEnabled != nil || startSleepTime != nil || endSleepTime != nil || timeZone != nil || lang != nil, "At least one or more should be provided when executing this request")
 
         let path = "account/settings.json"
@@ -71,7 +71,7 @@ public extension Swifter {
         parameters["time_zone"] ??= timeZone
         parameters["lang"] ??= lang
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -79,7 +79,7 @@ public extension Swifter {
 
     Sets values that users are able to set under the "Account" tab of their settings page. Only the parameters specified will be updated.
     */
-    public func updateUserProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateUserProfile(name: String? = nil, url: String? = nil, location: String? = nil, description: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(name != nil || url != nil || location != nil || description != nil || includeEntities != nil || skipStatus != nil)
 
         let path = "account/update_profile.json"
@@ -92,7 +92,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
         
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -100,7 +100,7 @@ public extension Swifter {
 
     Updates the authenticating user's profile background image. This method can also be used to enable or disable the profile background image. Although each parameter is marked as optional, at least one of image, tile or use must be provided when making this request.
     */
-    public func updateProfileBackground(using imageData: Data, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileBackground(using imageData: Data, title: String? = nil, includeEntities: Bool? = nil, use: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         assert(title != nil || use != nil, "At least one of image, tile or use must be provided when making this request")
 
         let path = "account/update_profile_background_image.json"
@@ -111,7 +111,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["use"] ??= use
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -119,7 +119,7 @@ public extension Swifter {
 
     Sets one or more hex values that control the color scheme of the authenticating user's profile page on twitter.com. Each parameter's value must be a valid hexidecimal value, and may be either three or six characters (ex: #fff or #ffffff).
     */
-    public func updateProfileColors(backgroundColor: String? = nil, linkColor: String? = nil, sidebarBorderColor: String? = nil, sidebarFillColor: String? = nil, textColor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func updateProfileColors(backgroundColor: String? = nil, linkColor: String? = nil, sidebarBorderColor: String? = nil, sidebarFillColor: String? = nil, textColor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "account/update_profile_colors.json"
 
         var parameters = Dictionary<String, Any>()
@@ -131,7 +131,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -141,7 +141,7 @@ public extension Swifter {
 
     This method asynchronously processes the uploaded file before updating the user's profile image URL. You can either update your local cache the next time you request the user's information, or, at least 5 seconds after uploading the image, ask for the updated URL using GET users/show.
     */
-    public func updateProfileImage(using imageData: Data, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileImage(using imageData: Data, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/update_profile_image.json"
 
         var parameters = Dictionary<String, Any>()
@@ -149,7 +149,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -157,7 +157,7 @@ public extension Swifter {
 
     Returns a collection of user objects that the authenticating user is blocking.
     */
-    public func getBlockedUsers(includeEntities: Bool? = nil, skipStatus: Bool? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getBlockedUsers(includeEntities: Bool? = nil, skipStatus: Bool? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "blocks/list.json"
 
         var parameters = Dictionary<String, Any>()
@@ -167,7 +167,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -175,7 +175,7 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user is blocking.
     */
-    public func getBlockedUsersIDs(stringifyIDs: String? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func getBlockedUsersIDs(stringifyIDs: String? = nil, cursor: String? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "blocks/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -184,7 +184,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -192,7 +192,7 @@ public extension Swifter {
 
     Blocks the specified user from following the authenticating user. In addition the blocked user will not show in the authenticating users mentions or timeline (unless retweeted by another user). If a follow or friend relationship exists it is destroyed.
     */
-    public func blockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func blockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "blocks/create.json"
 
         var parameters = Dictionary<String, Any>()
@@ -200,7 +200,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -208,7 +208,7 @@ public extension Swifter {
 
     Un-blocks the user specified in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format when successful. If relationships existed before the block was instated, they will not be restored.
     */
-    public func unblockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func unblockUser(for userTag: UserTag, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "blocks/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -216,7 +216,7 @@ public extension Swifter {
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -236,14 +236,14 @@ public extension Swifter {
     - If none of your lookup criteria can be satisfied by returning a user object, a HTTP 404 will be thrown.
     - You are strongly encouraged to use a POST for larger requests.
     */
-    public func lookupUsers(for usersTag: UsersTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func lookupUsers(for usersTag: UsersTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "users/lookup.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[usersTag.key] = usersTag.value
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -253,14 +253,14 @@ public extension Swifter {
 
     You must be following a protected user to be able to see their most recent Tweet. If you don't follow a protected user, the users Tweet will be removed. A Tweet will not always be returned in the current_status field.
     */
-    public func showUser(for userTag: UserTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func showUser(for userTag: UserTag, includeEntities: Bool? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "users/show.json"
 
         var parameters = Dictionary<String, Any>()
         parameters[userTag.key] = userTag.value
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -270,7 +270,7 @@ public extension Swifter {
 
     Only the first 1,000 matching results are available.
     */
-    public func searchUsers(using query: String, page: Int?, count: Int?, includeEntities: Bool?, success: SuccessHandler? = nil, failure: @escaping FailureHandler) {
+    public func searchUsers(using query: String, page: Int?, count: Int?, includeEntities: Bool?, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: @escaping FailureHandler) {
         let path = "users/search.json"
 
         var parameters = Dictionary<String, Any>()
@@ -279,7 +279,7 @@ public extension Swifter {
         parameters["count"] ??= count
         parameters["include_entities"] ??= includeEntities
 
-        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -287,10 +287,10 @@ public extension Swifter {
 
     Removes the uploaded profile banner for the authenticating user. Returns HTTP 200 upon success.
     */
-    public func removeProfileBanner(success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func removeProfileBanner(success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/remove_profile_banner.json"
 
-        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: [:], success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -307,7 +307,7 @@ public extension Swifter {
     400	Either an image was not provided or the image data could not be processed
     422	The image could not be resized or is too large.
     */
-    public func updateProfileBanner(using imageData: Data, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func updateProfileBanner(using imageData: Data, width: Int? = nil, height: Int? = nil, offsetLeft: Int? = nil, offsetTop: Int? = nil, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "account/update_profile_banner.json"
 
         var parameters = Dictionary<String, Any>()
@@ -317,7 +317,7 @@ public extension Swifter {
         parameters["offset_left"] ??= offsetLeft
         parameters["offset_top"] ??= offsetTop
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -325,11 +325,11 @@ public extension Swifter {
 
     Returns a map of the available size variations of the specified user's profile banner. If the user has not uploaded a profile banner, a HTTP 404 will be served instead. This method can be used instead of string manipulation on the profile_banner_url returned in user objects as described in User Profile Images and Banners.
     */
-    public func getProfileBanner(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getProfileBanner(for userTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "users/profile_banner.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -341,11 +341,11 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func muteUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func muteUser(for userTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/create.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, failure: failure)
+        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in success?(json) }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -357,7 +357,7 @@ public extension Swifter {
 
     Actions taken in this method are asynchronous and changes will be eventually consistent.
     */
-    public func unmuteUser(for userTag: UserTag, success: SuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func unmuteUser(for userTag: UserTag, success: SuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/destroy.json"
 
         var parameters = Dictionary<String, Any>()
@@ -365,7 +365,7 @@ public extension Swifter {
 
         self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
 
     /**
@@ -373,7 +373,7 @@ public extension Swifter {
 
     Returns an array of numeric user ids the authenticating user has muted.
     */
-    public func getMuteUsersIDs(cursor: String? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getMuteUsersIDs(cursor: String? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/ids.json"
 
         var parameters = Dictionary<String, Any>()
@@ -381,7 +381,7 @@ public extension Swifter {
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["ids"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
     /**
@@ -389,7 +389,7 @@ public extension Swifter {
     
     Returns an array of user objects the authenticating user has muted.
     */
-    public func getMuteUsers(cursor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: CursorSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    public func getMuteUsers(cursor: String? = nil, includeEntities: Bool? = nil, skipStatus: Bool? = nil, success: CursorSuccessHandler? = nil, rawSuccess: RawSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "mutes/users/list.json"
         
         var parameters = Dictionary<String, Any>()
@@ -399,7 +399,7 @@ public extension Swifter {
         
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json["users"], json["previous_cursor_str"].string, json["next_cursor_str"].string)
-            }, failure: failure)
+            }, rawSuccess: rawSuccess, failure: failure)
     }
     
 }


### PR DESCRIPTION
As mentioned in #203, I found my previous solution to this problem #196 had a few issues in practice. I also would prefer not to have to maintain an independent fork if I don't have to. So I decided to take another go at it, and the solution I came up with this time is more flexible, much simpler and more ergonomic than the old one. It's also slightly different from what I proposed in the above issue.

At the core of this pull request is a new type, `RawSuccessHandler`, which wraps a simple closure. A single parameter of this type is added to each endpoint method. The user can initialize it with one of three static methods to get either just the raw data, the raw data and a decoded value, or just a decoded value respectively--alternative name suggestions welcome:
- `public static func data(handler: @escaping (Data) -> Void) -> RawSuccessHandler`
- `public static func dataAndDecoding<Entity: Decodable>(_ type: Entity.Type, handler: @escaping (Data, Entity?) -> Void) -> RawSuccessHandler`
- `public static func decoding<Entity: Decodable>(_ type: Entity.Type, handler: @escaping (Entity) -> Void) -> RawSuccessHandler`

Behind the scenes, the closure wrapped by `RawSuccessHandler` itself accepts a `Swifter.FailureHandler`, which `jsonRequest()` takes advantage of to propagate decoding errors to the user-provided failure handler.

Below are some code samples.

Prints the home timeline in JSON form:
```
swifter.getHomeTimeline(
    rawSuccess: .data { data in
        print(String(data: data, encoding: .utf8)!)
    }
)
```

Prints the home timeline in JSON form, prints a belittling message, then prints a decoding error:
```
swifter.getHomeTimeline(
    rawSuccess: .dataAndDecoding(Int.self) { data, timeline in
        print(String(data: data, encoding: .utf8)!)
        print(timeline ?? "The home timeline isn't an integer, dummy!")
    },
    failure: { error in print(error) }
)
```

Prints the text of each tweet in the home timeline:
```
struct Tweet: Decodable {
    let text: String
}
swifter.getHomeTimeline(
    rawSuccess: .decoding([Tweet].self) { tweets in
        for tweet in tweets {
            print(tweet.text)
        }
    }
)
```