### PR TITLE
Fix for broken tweetGIF function

### DIFF
--- a/Sources/SwifterGIF.swift
+++ b/Sources/SwifterGIF.swift
@@ -22,7 +22,7 @@ public extension Swifter {
 			if let media_id = json["media_id_string"].string {
 				self.uploadGIF(media_id, data: data, name: attachment.lastPathComponent, success: { json, response in
 					self.finalizeUpload(mediaId: media_id, success: { json, resoponse in
-						self.postTweet(status: text, media_ids: [media_id], success: success, failure: failure)
+						self.postTweet(status: text, media: data, success: success, failure: failure)
 					}, failure: failure)
 				}, failure: failure)
 			}


### PR DESCRIPTION
- With this commit Xcode can build the project
- Post tweet function which is used by tweetGIF function has different parameter identifier and type for `media`  and `Data`.