### PR TITLE
Added support for getting email & more

### DIFF
--- a/Sources/SwifterAuth.swift
+++ b/Sources/SwifterAuth.swift
@@ -80,6 +80,7 @@ public extension Swifter {
     public func authorize(withCallback callbackURL: URL,
 						  presentingFrom presenting: UIViewController?,
 						  forceLogin: Bool = false,
+						  safariDelegate: SFSafariViewControllerDelegate? = nil,
 						  success: TokenSuccessHandler?,
 						  failure: FailureHandler? = nil) {
         self.postOAuthRequestToken(with: callbackURL, success: { token, response in
@@ -102,7 +103,7 @@ public extension Swifter {
 			let query = "oauth/authorize?oauth_token=\(token!.key)\(forceLogin)"
             let queryUrl = URL(string: query, relativeTo: TwitterURL.oauth.url)!
 			
-            if #available(iOS 9.0, *) , let delegate = presenting as? SFSafariViewControllerDelegate {
+            if let delegate = safariDelegate ?? (presenting as? SFSafariViewControllerDelegate) {
                 let safariView = SFSafariViewController(url: queryUrl)
                 safariView.delegate = delegate
                 presenting?.present(safariView, animated: true, completion: nil)

--- a/Sources/SwifterAuth.swift
+++ b/Sources/SwifterAuth.swift
@@ -106,6 +106,8 @@ public extension Swifter {
             if let delegate = safariDelegate ?? (presenting as? SFSafariViewControllerDelegate) {
                 let safariView = SFSafariViewController(url: queryUrl)
                 safariView.delegate = delegate
+                safariView.modalTransitionStyle = .coverVertical
+                safariView.modalPresentationStyle = .overFullScreen
                 presenting?.present(safariView, animated: true, completion: nil)
             } else {
                 UIApplication.shared.openURL(queryUrl)

--- a/Sources/SwifterUsers.swift
+++ b/Sources/SwifterUsers.swift
@@ -48,6 +48,7 @@ public extension Swifter {
     */
     public func verifyAccountCredentials(includeEntities: Bool? = nil,
 										 skipStatus: Bool? = nil,
+										 includeEmail: Bool? = nil,
 										 success: SuccessHandler? = nil,
 										 failure: FailureHandler? = nil) {
         let path = "account/verify_credentials.json"
@@ -55,6 +56,7 @@ public extension Swifter {
         var parameters = [String: Any]()
         parameters["include_entities"] ??= includeEntities
         parameters["skip_status"] ??= skipStatus
+        parameters["include_email"] ??= includeEmail
 
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
 			success?(json)


### PR DESCRIPTION
I added support to get the user email if you have the right permissions with `include_email ` parameter.

Also added support for a custom `SFSafariViewControllerDelegate ` in case you don't what your view controller to handle it if this is not set it uses the view controller as it was before.

Removed the` #available(iOS 9.0, *)` because the minimum deploy target is already iOS9 so I don't think there is a need to check for it.

Updated the prevent animation to match the one used by other social logins (Facebook and Google)

If you think that some of these do not make sense I can remove them.

