### PR TITLE
Enhancement/timeline

### DIFF
--- a/Sources/SwifterAuth.swift
+++ b/Sources/SwifterAuth.swift
@@ -74,6 +74,9 @@ public extension Swifter {
      - Parameter presentFromViewController: The viewController used to present the SFSafariViewController.
      The UIViewController must inherit SFSafariViewControllerDelegate
      
+     This authentication is only needed once. For future Swifter initializations, persist the access token (and access token secret) returned from the authentication callback, then in subsequent app sessions create the Swifter instance with the tokens themselves using the following initializer:
+     public init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String)
+     
      */
     
     #if os(iOS)

--- a/Sources/SwifterTimelines.swift
+++ b/Sources/SwifterTimelines.swift
@@ -92,45 +92,45 @@ public extension Swifter {
 
 
     /**
-     GET    statuses/user_timeline
-     Returns Tweets (*: tweets for the user)
-     
-     Returns a collection of the most recent Tweets posted by the user indicated by the user_id parameter.
-     
-     User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
-     
-     The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
-     
-     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
-     */
+    GET	statuses/user_timeline
+    Returns Tweets (*: tweets for the user)
+
+    Returns a collection of the most recent Tweets posted by the user indicated by the user_id parameter.
+
+    User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
+
+    The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
+
+    This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
+    */
     public func getTimeline(for userID: String,
-                            customParam: [String: Any] = [:],
-                            count: Int? = nil,
-                            sinceID: String? = nil,
-                            maxID: String? = nil,
-                            trimUser: Bool? = nil,
-                            excludeReplies: Bool? = nil,
-                            includeRetweets: Bool? = nil,
-                            contributorDetails: Bool? = nil,
-                            includeEntities: Bool? = nil,
-                            tweetMode: TweetMode = .default,
-                            success: SuccessHandler? = nil,
-                            failure: FailureHandler? = nil) {
+							customParam: [String: Any] = [:],
+							count: Int? = nil,
+							sinceID: String? = nil,
+							maxID: String? = nil,
+							trimUser: Bool? = nil,
+							excludeReplies: Bool? = nil,
+							includeRetweets: Bool? = nil,
+							contributorDetails: Bool? = nil,
+							includeEntities: Bool? = nil,
+							tweetMode: TweetMode = .default,
+							success: SuccessHandler? = nil,
+							failure: FailureHandler? = nil) {
         var parameters: [String: Any] = customParam
-        parameters["user_id"] = userID
-        self.getTimeline(at: "statuses/user_timeline.json",
-                         parameters: parameters,
-                         count: count,
-                         sinceID: sinceID,
-                         maxID: maxID,
-                         trimUser: trimUser,
-                         excludeReplies: excludeReplies,
-                         includeRetweets: includeRetweets,
-                         contributorDetails: contributorDetails,
-                         includeEntities: includeEntities,
-                         tweetMode: tweetMode,
-                         success: success,
-                         failure: failure)
+		parameters["user_id"] = userID
+		self.getTimeline(at: "statuses/user_timeline.json",
+						 parameters: parameters,
+						 count: count,
+						 sinceID: sinceID,
+						 maxID: maxID,
+						 trimUser: trimUser,
+						 excludeReplies: excludeReplies,
+						 includeRetweets: includeRetweets,
+						 contributorDetails: contributorDetails,
+						 includeEntities: includeEntities,
+						 tweetMode: tweetMode,
+						 success: success,
+						 failure: failure)
     }
     
     /**

--- a/Sources/SwifterTimelines.swift
+++ b/Sources/SwifterTimelines.swift
@@ -92,45 +92,87 @@ public extension Swifter {
 
 
     /**
-    GET	statuses/user_timeline
-    Returns Tweets (*: tweets for the user)
-
-    Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
-
-    User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
-
-    The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
-
-    This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
-    */
+     GET    statuses/user_timeline
+     Returns Tweets (*: tweets for the user)
+     
+     Returns a collection of the most recent Tweets posted by the user indicated by the user_id parameter.
+     
+     User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
+     
+     The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
+     
+     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
+     */
     public func getTimeline(for userID: String,
-							customParam: [String: Any] = [:],
-							count: Int? = nil,
-							sinceID: String? = nil,
-							maxID: String? = nil,
-							trimUser: Bool? = nil,
-							excludeReplies: Bool? = nil,
-							includeRetweets: Bool? = nil,
-							contributorDetails: Bool? = nil,
-							includeEntities: Bool? = nil,
-							tweetMode: TweetMode = .default,
-							success: SuccessHandler? = nil,
-							failure: FailureHandler? = nil) {
+                            customParam: [String: Any] = [:],
+                            count: Int? = nil,
+                            sinceID: String? = nil,
+                            maxID: String? = nil,
+                            trimUser: Bool? = nil,
+                            excludeReplies: Bool? = nil,
+                            includeRetweets: Bool? = nil,
+                            contributorDetails: Bool? = nil,
+                            includeEntities: Bool? = nil,
+                            tweetMode: TweetMode = .default,
+                            success: SuccessHandler? = nil,
+                            failure: FailureHandler? = nil) {
         var parameters: [String: Any] = customParam
-		parameters["user_id"] = userID
-		self.getTimeline(at: "statuses/user_timeline.json",
-						 parameters: parameters,
-						 count: count,
-						 sinceID: sinceID,
-						 maxID: maxID,
-						 trimUser: trimUser,
-						 excludeReplies: excludeReplies,
-						 includeRetweets: includeRetweets,
-						 contributorDetails: contributorDetails,
-						 includeEntities: includeEntities,
-						 tweetMode: tweetMode,
-						 success: success,
-						 failure: failure)
+        parameters["user_id"] = userID
+        self.getTimeline(at: "statuses/user_timeline.json",
+                         parameters: parameters,
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         excludeReplies: excludeReplies,
+                         includeRetweets: includeRetweets,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         tweetMode: tweetMode,
+                         success: success,
+                         failure: failure)
+    }
+    
+    /**
+     GET    statuses/user_timeline
+     Returns Tweets (*: tweets for the user)
+     
+     Returns a collection of the most recent Tweets posted by the user indicated by the screen_name parameter.
+     
+     User timelines belonging to protected users may only be requested when the authenticated user either "owns" the timeline or is an approved follower of the owner.
+     
+     The timeline returned is the equivalent of the one seen when you view a user's profile on twitter.com.
+     
+     This method can only return up to 3,200 of a user's most recent Tweets. Native retweets of other statuses by the user is included in this total, regardless of whether include_rts is set to false when requesting this resource.
+     */
+    public func getTimeline(forScreenName screenName: String,
+                            customParam: [String: Any] = [:],
+                            count: Int? = nil,
+                            sinceID: String? = nil,
+                            maxID: String? = nil,
+                            trimUser: Bool? = nil,
+                            excludeReplies: Bool? = nil,
+                            includeRetweets: Bool? = nil,
+                            contributorDetails: Bool? = nil,
+                            includeEntities: Bool? = nil,
+                            tweetMode: TweetMode = .default,
+                            success: SuccessHandler? = nil,
+                            failure: FailureHandler? = nil) {
+        var parameters: [String: Any] = customParam
+        parameters["screen_name"] = screenName
+        self.getTimeline(at: "statuses/user_timeline.json",
+                         parameters: parameters,
+                         count: count,
+                         sinceID: sinceID,
+                         maxID: maxID,
+                         trimUser: trimUser,
+                         excludeReplies: excludeReplies,
+                         includeRetweets: includeRetweets,
+                         contributorDetails: contributorDetails,
+                         includeEntities: includeEntities,
+                         tweetMode: tweetMode,
+                         success: success,
+                         failure: failure)
     }
 
     /**


### PR DESCRIPTION
1. added function for fetching timeline by screen name:

Previous timeline func returned authenticated user timeline if a screen name was entered as "for userID" argument. 

Previous timeline func required one to do this to get timeline by screen name: swifter.getTimeline(for: "", customParam: ["screen_name":"jack"], count: nil...

2. added comment on multi-session swifter init w/ persisted creds:

I found that other libraries similar to this one persist the tokens for the library user, because of this I thought a comment would help future library users.