### PR TITLE
Fix pretty print json

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -184,7 +184,7 @@ public enum JSON : Equatable, CustomStringConvertible {
             return "\(number)"
             
         case .string(let string):
-            return "\"\(string.replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\r", with: "").replacingOccurrences(of: "\n", with: "\\n"))\""
+            return "\"\(string.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"").replacingOccurrences(of: "\r", with: "").replacingOccurrences(of: "\n", with: "\\n"))\""
             
         case .array(let array):
             return "[\n" + array.map { "\(nextIndent)\($0.prettyPrint(indent, level + 1))" }.joined(separator: ",\n") + "\n\(currentIndent)]"

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4ED2E25C215E1E1A00E2084A /* JSONTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED2E25B215E1E1A00E2084A /* JSONTest.swift */; };
 		8B116AF1194601970019A4DC /* SwifterHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B116AF0194601970019A4DC /* SwifterHTTPRequest.swift */; };
 		8B116AF2194601970019A4DC /* SwifterHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B116AF0194601970019A4DC /* SwifterHTTPRequest.swift */; };
 		8B1F259F194A663D004BD304 /* SwifterHelp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1F259E194A663D004BD304 /* SwifterHelp.swift */; };
@@ -153,6 +154,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4ED2E25B215E1E1A00E2084A /* JSONTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTest.swift; sourceTree = "<group>"; };
 		8B116AF0194601970019A4DC /* SwifterHTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterHTTPRequest.swift; sourceTree = "<group>"; };
 		8B1F259E194A663D004BD304 /* SwifterHelp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwifterHelp.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8B300C1F1944AA1A00993175 /* SwifterDemoiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwifterDemoiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -399,6 +401,7 @@
 				DC7D6B711ECA5294008586E3 /* Info.plist */,
 				DC7D6B721ECA5294008586E3 /* String+SwifterTests.swift */,
 				DC7D6B731ECA5294008586E3 /* SwifterTests.swift */,
+				4ED2E25B215E1E1A00E2084A /* JSONTest.swift */,
 			);
 			name = SwifterTests;
 			path = Tests/SwifterTests;
@@ -729,6 +732,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4ED2E25C215E1E1A00E2084A /* JSONTest.swift in Sources */,
 				DC7D6B761ECA5294008586E3 /* SwifterTests.swift in Sources */,
 				DC7D6B751ECA5294008586E3 /* String+SwifterTests.swift in Sources */,
 			);

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -1055,7 +1055,6 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Tests/SwifterTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattdonnelly.SwifteriOS.SwifterTests;
@@ -1071,7 +1070,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Tests/SwifterTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattdonnelly.SwifteriOS.SwifterTests;

--- a/Tests/SwifterTests/JSONTest.swift
+++ b/Tests/SwifterTests/JSONTest.swift
@@ -1,0 +1,52 @@
+//
+//  JSONTest.swift
+//  SwifterTests
+//
+//  Created by mironal on 2018/09/28.
+//  Copyright © 2018年 Matt Donnelly. All rights reserved.
+//
+
+import XCTest
+
+#if os(iOS)
+@testable import SwifteriOS
+#elseif os(macOS)
+@testable import SwifterMac
+#elseif os(Linux)
+@testable import Swifter
+#endif
+
+
+class JSONTest: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /*
+
+     Because to forgot the escape of /, An exteption raised when parsing
+     a string acquired using "String(describing: )" or "description" to JSON object.
+
+     */
+    func testFixCanNotParseStringFromDescription() throws {
+
+        let obj:[String: String] = ["key": "this is invalid string -> \\ <-"]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: obj, options: [])
+
+        let json = try JSON.parse(jsonData: jsonData)
+
+        guard let data = json.description.data(using: .utf8) else {
+            XCTFail()
+            fatalError()
+        }
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: data, options: []))
+        XCTAssertEqual(try JSONSerialization.jsonObject(with: data, options: []) as! [String: String], obj)
+    }
+}


### PR DESCRIPTION
Hi! 😄  

I'm using Swifter like following.

```swift
// let json = ... // A JSON instance from Swifter.
let jsonStr = String(describing: json)
// some thing...
let jsonData = jsonStr.data(using: .utf8)
let object = try JSONSerialization.jsonObject(with: jsonData, options: []) // <- An error occurred.
```

But I got the following error. :cry:

`"Error Domain=NSCocoaErrorDomain Code=3840 "Invalid escape sequence around character 39." UserInfo={NSDebugDescription=Invalid escape sequence around character 39.}"`

I thought that strings made from JSON instances should be convertible to JSON.

So I fixed it to be that way.
