### PR TITLE
Building with Swift 4.2 on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,17 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 let package = Package(
-    name: "Swifter"
+    name: "Swifter",
+    products: [
+        .library(name: "Swifter", targets: ["Swifter"]),
+    ],
+    targets: [
+        .target(
+            name: "Swifter",
+            path: "Sources"
+        ),
+    ],
+    swiftLanguageVersions: [.v4_2]
 )

--- a/Sources/Scanner++.swift
+++ b/Sources/Scanner++.swift
@@ -12,12 +12,20 @@ import Foundation
 /// swift-corelibs-foundation. These are exactly the same API as in
 /// https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSScanner.swift
 extension Scanner {
-    #if os(macOS) || os(iOS)
+    #if os(Linux)
+    func scanString(string: String) -> String? {
+        var buffer: String?
+        _ = scanString(string, into: &buffer)
+        return buffer
+    }
+    #elseif os(iOS) || os(macOS)
     func scanString(string: String) -> String? {
         var buffer: NSString?
-        scanString(string, into: &buffer)
+        _ = scanString(string, into: &buffer)
         return buffer as String?
     }
+    #endif
+    #if os(iOS) || os(macOS)
     func scanUpToString(_ string: String) -> String? {
         var buffer: NSString?
         scanUpTo(string, into: &buffer)


### PR DESCRIPTION
I tried building Swifter on Linux (Raspbian) with Swift 4.2 (https://ko-fi.com/post/Swift-4-2-Binaries-F1F6KMBY) and SPM but the build would always fail with this error:

```
String++.swift:65:35: error: extraneous argument label 'string:' in call
            _ = scanner.scanString(string: "=")
```

I managed to get it working by slightly changing the `Scanner` extensions, specifically by making the `scanString(string:)` method available on Linux.

I am, however, not sure if this change would break something in a different build environment.