### PR TITLE
Fixed getProfileBanner error.

### DIFF
--- a/Sources/SwifterUsers.swift
+++ b/Sources/SwifterUsers.swift
@@ -428,7 +428,7 @@ public extension Swifter {
         let path = "users/profile_banner.json"
         let parameters: [String: Any] = [userTag.key: userTag.value]
 
-        self.postJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
+        self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
 			success?(json)
 		}, failure: failure)
     }


### PR DESCRIPTION
Dear swifter developers.

Hello. Now I create my homebrew twitter client and get my profile banner & images.

I called "getProfileBanner" function when got a "Method not allowed(405)" error.

this function uses the "POST" method. Maybe correct is the "GET" method.

https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners.html

Please review my code.

Thx!