### PR TITLE
Fix key misspelling

### DIFF
--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -253,7 +253,7 @@ public extension Swifter {
         let path: String = "media/upload.json"
         var parameters = [String: Any]()
         parameters["media"] = media
-        parameters["additional_owers"] ??= additionalOwners?.value
+        parameters["additional_owners"] ??= additionalOwners?.value
         parameters[Swifter.DataParameters.dataKey] = "media"
 
         self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: {


### PR DESCRIPTION
"additional_owers" to "additional_owners"

Maybe it is correct in the Twitter API Document.

https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload

Please check this PR. Thx.
