### PR TITLE
Resolved issue causing multiple listeners to remain active

### DIFF
--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -107,6 +107,13 @@ public class Swifter {
     public var client: SwifterClientProtocol
     private var chunkBuffer: String?
 
+    internal var swifterCallbackToken: NSObjectProtocol? {
+        willSet {
+            guard let token = swifterCallbackToken else { return }
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
     // MARK: - Initializers
     
     public init(consumerKey: String, consumerSecret: String, appOnly: Bool = false) {

--- a/Sources/SwifterAuth.swift
+++ b/Sources/SwifterAuth.swift
@@ -85,8 +85,8 @@ public extension Swifter {
 						  failure: FailureHandler? = nil) {
         self.postOAuthRequestToken(with: callbackURL, success: { token, response in
             var requestToken = token!
-            NotificationCenter.default.addObserver(forName: .swifterCallback, object: nil, queue: .main) { notification in
-                NotificationCenter.default.removeObserver(self)
+            self.swifterCallbackToken = NotificationCenter.default.addObserver(forName: .swifterCallback, object: nil, queue: .main) { notification in
+                self.swifterCallbackToken = nil
                 presenting?.presentedViewController?.dismiss(animated: true, completion: nil)
                 let url = notification.userInfo![CallbackNotification.optionsURLKey] as! URL
                 


### PR DESCRIPTION
This is a more proper way removing block based listeners.  `NotificationCenter.default.removeObserver(self)` does nothing.