### PR TITLE
changed type of Parameter maxId from String to Int64

### DIFF
--- a/Sources/SwifterLists.swift
+++ b/Sources/SwifterLists.swift
@@ -60,7 +60,7 @@ public extension Swifter {
      */
     func listTweets(for listTag: ListTag,
                     sinceID: String? = nil,
-                    maxID: String? = nil,
+                    maxID: Int64? = nil,
                     count: Int? = nil,
                     includeEntities: Bool? = nil,
                     includeRTs: Bool? = nil,


### PR DESCRIPTION
MaxID on listsTweets expects a number not a String