### PR TITLE
Support SSO error handling when ignore authorization step.

### DIFF
--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -95,6 +95,7 @@ public class Swifter {
     
     internal struct CallbackNotification {
         static let optionsURLKey = "SwifterCallbackNotificationOptionsURLKey"
+        static let optionsUserCancelKey = "SwifterCallbackNotificationOptionsUserCancelKey"
     }
     
     internal struct DataParameters {
@@ -107,6 +108,7 @@ public class Swifter {
     
     public var client: SwifterClientProtocol
     private var chunkBuffer: String?
+    private var appSwitchingObserver: AppSwitchingObserver?
     
     internal var swifterCallbackToken: NSObjectProtocol? {
         willSet {

--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -108,7 +108,7 @@ public class Swifter {
     
     public var client: SwifterClientProtocol
     private var chunkBuffer: String?
-    private var appSwitchingObserver: AppSwitchingObserver?
+    internal var appSwitchingObserver: AppSwitchingObserver?
     
     internal var swifterCallbackToken: NSObjectProtocol? {
         willSet {


### PR DESCRIPTION
When user using sso, user can skip authorization step and switch master app.
This case is should deal as cancel.
For example, LINE-SDK(LINE is famous messaging app for jpn) implements this case using timeout logic.
https://github.com/line/line-sdk-ios-swift/blob/master/LineSDK/LineSDK/Login/LoginProcess.swift#L173

This PR is implemented same logic as LINE-SDK.
Please review this. 👍 