### PR TITLE
Can support all APIs.

### DIFF
--- a/Sources/Swifter.swift
+++ b/Sources/Swifter.swift
@@ -213,7 +213,7 @@ public class Swifter {
     }
     
     @discardableResult
-    internal func getJSON(path: String,
+    public func getJSON(path: String,
                           baseURL: TwitterURL,
                           parameters: [String: Any],
                           uploadProgress: HTTPRequest.UploadProgressHandler? = nil,
@@ -226,7 +226,7 @@ public class Swifter {
     }
     
     @discardableResult
-    internal func postJSON(path: String,
+    public func postJSON(path: String,
                            baseURL: TwitterURL,
                            parameters: [String: Any],
                            uploadProgress: HTTPRequest.UploadProgressHandler? = nil,
@@ -239,7 +239,7 @@ public class Swifter {
     }
     
     @discardableResult
-    internal func deleteJSON(path: String,
+    public func deleteJSON(path: String,
                              baseURL: TwitterURL,
                              parameters: [String: Any],
                              success: JSONSuccessHandler?,


### PR DESCRIPTION
This library does not support collection API and video upload.
Exposing this method allows you to be more flexible with various APIs and new APIs.