### PR TITLE
fix Swift 5 warning: Initialization of "UnsafePointer<UInt8>" results…

### DIFF
--- a/Sources/Data++.swift
+++ b/Sources/Data++.swift
@@ -16,12 +16,8 @@ extension Data {
     }
     
     init(bytes: [UInt8]) {
-        self.init(bytes: UnsafePointer<UInt8>(bytes), count: bytes.count)
+        self.init(bytes)
     }
     
-    mutating func append(_ bytes: [UInt8]) {
-        self.append(UnsafePointer<UInt8>(bytes), count: bytes.count)
-    }
-
 }
 

--- a/Sources/HMAC.swift
+++ b/Sources/HMAC.swift
@@ -38,7 +38,7 @@ public struct HMAC {
         let finalHash = SHA1(Data(bytes: opad + ipadAndMessageHash)).calculate()
         let mac = finalHash
 
-        return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
+        return Data(bytes: mac)
 
     }
 


### PR DESCRIPTION
… in a dangling pointer