### PR TITLE
Get all categories.

### DIFF
--- a/Sources/SwifterHelp.swift
+++ b/Sources/SwifterHelp.swift
@@ -96,11 +96,12 @@ public extension Swifter {
      
      Read more about REST API Rate Limiting in v1.1 and review the limits.
      */
-    func getRateLimits(for resources: [String],
+    func getRateLimits(for resources: [String]? = nil,
                        success: SuccessHandler? = nil,
                        failure: FailureHandler? = nil) {
         let path = "application/rate_limit_status.json"
-        let parameters = ["resources": resources.joined(separator: ",")]
+        var parameters = [String: Any]()
+        parameters["resources"] ??= resources.joined(separator: ",")
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
         }, failure: failure)


### PR DESCRIPTION
The rate limit API can get all categories without specifying "resources" in the parameter.
 Could not get all categories even if you specify an empty array in [String] ().

![スクリーンショット 2020-05-16 23 41 36](https://user-images.githubusercontent.com/20889032/82123664-84cbd300-97d5-11ea-8561-a4d03ddaf10b.png)

So "resources" should be optional.