### PR TITLE
Fix unwrapped variable "resources"s handling

### DIFF
--- a/Sources/SwifterHelp.swift
+++ b/Sources/SwifterHelp.swift
@@ -101,7 +101,7 @@ public extension Swifter {
                        failure: FailureHandler? = nil) {
         let path = "application/rate_limit_status.json"
         var parameters = [String: Any]()
-        parameters["resources"] ??= resources.joined(separator: ",")
+        parameters["resources"] ??= resources?.joined(separator: ",")
         self.getJSON(path: path, baseURL: .api, parameters: parameters, success: { json, _ in
             success?(json)
         }, failure: failure)


### PR DESCRIPTION
In the commit [23db8e0](https://github.com/mattdonnelly/Swifter/commit/23db8e0ece26b02de9c94dbc5bca1a5710470322) that becomes to allow you to call the function `getRateLimits` without setting parameter `resources`, an empty array will be assigned in default.

On this state, the error it will be occurred in line 104.
<img width="993" alt="スクリーンショット 2020-05-17 17 15 00" src="https://user-images.githubusercontent.com/51850597/82139353-23057a80-9862-11ea-99ea-feda893004e7.png">

To solve this, rewrite `resources .joined (...)` with `resources? .joined (...)`.

<img width="715" alt="スクリーンショット 2020-05-17 16 55 35" src="https://user-images.githubusercontent.com/51850597/82139235-66131e00-9861-11ea-8d05-497cf61124a1.png">
