### PR TITLE
Patched Media Upload for PostTweet

### DIFF
--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -76,6 +76,7 @@ public extension Swifter {
                     failure?(error)
                 }
             } else {
+                print("json: ", json)
                 let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)
                 failure?(error)
             }

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -23,7 +23,7 @@ public enum MediaCategory: String {
 
 public extension Swifter {
     
-    internal func prepareUpload(data: Data, type: MediaType, category: MediaCategory?, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    internal func prepareUpload(data: Data, type: MediaType, category: MediaCategory? = nil, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "media/upload.json"
         var parameters: [String : Any] = ["command": "INIT",
                                           "total_bytes": data.count,

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -19,17 +19,18 @@ public enum MediaType: String {
 public enum MediaCategory: String {
     case gif = "tweet_gif"
     case video = "tweet_video"
-    case null = ""
 }
 
 public extension Swifter {
     
-    internal func prepareUpload(data: Data, type: MediaType, category: MediaCategory, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
+    internal func prepareUpload(data: Data, type: MediaType, category: MediaCategory?, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "media/upload.json"
-        let parameters: [String : Any] = ["command": "INIT",
+        var parameters: [String : Any] = ["command": "INIT",
                                           "total_bytes": data.count,
                                           "media_type": type.rawValue]
-        //                                          "media_category": category.rawValue]
+        if let cat = category {
+            parameters["media_category"] = cat
+        }
         self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: success, failure: failure)
     }
     
@@ -75,8 +76,8 @@ public extension Swifter {
                                              kind: .invalidMultipartMediaResponse)
                     failure?(error)
                 }
-            } else if json != nil {
-                // success but with no state
+            } else if json != nil && response.statusCode >= 200 && response.statusCode <= 299 {
+                // success but with no state - use with caution!
                 success?(json, response)
             } else {
                 let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -19,6 +19,7 @@ public enum MediaType: String {
 public enum MediaCategory: String {
     case gif = "tweet_gif"
     case video = "tweet_video"
+    case null = ""
 }
 
 public extension Swifter {

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -28,8 +28,8 @@ public extension Swifter {
         let path = "media/upload.json"
         let parameters: [String : Any] = ["command": "INIT",
                                           "total_bytes": data.count,
-                                          "media_type": type.rawValue,
-                                          "media_category": category.rawValue]
+                                          "media_type": type.rawValue]
+//                                          "media_category": category.rawValue]
         self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: success, failure: failure)
     }
 

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -75,7 +75,7 @@ public extension Swifter {
                                              kind: .invalidMultipartMediaResponse)
                     failure?(error)
                 }
-            } else if let processingInfo = json["processing_info"].object{
+            } else if json != nil {
                 // success but with no state
                 success?(json, response)
             } else {

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -77,8 +77,9 @@ public extension Swifter {
                 }
             } else {
                 print("json: ", json)
-                let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)
-                failure?(error)
+//                let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)
+//                failure?(error)
+                success?(json, response)
             }
         }, failure: failure)
     }

--- a/Sources/SwifterMedia.swift
+++ b/Sources/SwifterMedia.swift
@@ -23,16 +23,16 @@ public enum MediaCategory: String {
 }
 
 public extension Swifter {
-
+    
     internal func prepareUpload(data: Data, type: MediaType, category: MediaCategory, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "media/upload.json"
         let parameters: [String : Any] = ["command": "INIT",
                                           "total_bytes": data.count,
                                           "media_type": type.rawValue]
-//                                          "media_category": category.rawValue]
+        //                                          "media_category": category.rawValue]
         self.postJSON(path: path, baseURL: .upload, parameters: parameters, success: success, failure: failure)
     }
-
+    
     internal func appendUpload(_ mediaId: String, data: Data, name: String? = nil, index: Int = 0, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "media/upload.json"
         let chunkSize: Int = 2 * 1024 * 1024
@@ -55,7 +55,7 @@ public extension Swifter {
             }
         }, failure: failure)
     }
-
+    
     internal func finalizeUpload(mediaId: String, success: JSONSuccessHandler? = nil, failure: FailureHandler? = nil) {
         let path = "media/upload.json"
         let parameters = ["command": "FINALIZE",
@@ -75,13 +75,14 @@ public extension Swifter {
                                              kind: .invalidMultipartMediaResponse)
                     failure?(error)
                 }
-            } else {
-                print("json: ", json)
-//                let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)
-//                failure?(error)
+            } else if let processingInfo = json["processing_info"].object{
+                // success but with no state
                 success?(json, response)
+            } else {
+                let error = SwifterError(message: "Cannot parse processing_info", kind: .jsonParseError)
+                failure?(error)
             }
         }, failure: failure)
     }
-
+    
 }

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -264,10 +264,10 @@ public extension Swifter {
     func postMultipartMedia(_ media: Data,
                             name: String? = nil,
                             type: MediaType,
-                            category: MediaCategory,
+                            category: MediaCategory? = nil,
                             success: SuccessHandler? = nil,
                             failure: FailureHandler? = nil) {
-        self.prepareUpload(data: media, type: type, category: category, success: { json, response in            
+        self.prepareUpload(data: media, type: type, category: category, success: { json, response in
             if let media_id = json["media_id_string"].string {
                 self.appendUpload(media_id, data: media, name: name, index: 0, success: { json, response in
                     self.finalizeUpload(mediaId: media_id, success: { (json, response) in

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -267,14 +267,10 @@ public extension Swifter {
                             category: MediaCategory,
                             success: SuccessHandler? = nil,
                             failure: FailureHandler? = nil) {
-        self.prepareUpload(data: media, type: type, category: category, success: { json, response in
-            print("swifter 1: ", json, response)
-            
+        self.prepareUpload(data: media, type: type, category: category, success: { json, response in            
             if let media_id = json["media_id_string"].string {
                 self.appendUpload(media_id, data: media, name: name, index: 0, success: { json, response in
-                    print("swifter 1: ", json, response)
                     self.finalizeUpload(mediaId: media_id, success: { (json, response) in
-                        print("swifter 1: ", json, response)
                         success?(json)
                     }, failure: failure)
                 }, failure: failure)

--- a/Sources/SwifterTweets.swift
+++ b/Sources/SwifterTweets.swift
@@ -268,9 +268,13 @@ public extension Swifter {
                             success: SuccessHandler? = nil,
                             failure: FailureHandler? = nil) {
         self.prepareUpload(data: media, type: type, category: category, success: { json, response in
+            print("swifter 1: ", json, response)
+            
             if let media_id = json["media_id_string"].string {
                 self.appendUpload(media_id, data: media, name: name, index: 0, success: { json, response in
-                    self.finalizeUpload(mediaId: media_id, success: { (json, _) in
+                    print("swifter 1: ", json, response)
+                    self.finalizeUpload(mediaId: media_id, success: { (json, response) in
+                        print("swifter 1: ", json, response)
                         success?(json)
                     }, failure: failure)
                 }, failure: failure)


### PR DESCRIPTION
Twitter's API doesn't like it when the media_category is set on an uploaded media file when that media file is to be used in a tweet.

Made the media_category optional.