### PR TITLE
Initial try to resolve issue #318 - Support for watchOS 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Swifter",
     platforms: [
-        .macOS(.v10_10), .iOS(.v10)
+        .macOS(.v10_10), .iOS(.v10), .watchOS(.v5)
     ],
     products: [
         .library(name: "Swifter", targets: ["Swifter"]),

--- a/Sources/Scanner++.swift
+++ b/Sources/Scanner++.swift
@@ -13,19 +13,19 @@ import Foundation
 /// https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSScanner.swift
 extension Scanner {
     #if os(Linux)
-    func scanString(string: String) -> String? {
-        var buffer: String?
-        _ = scanString(string, into: &buffer)
+    func scanString(_ string: String) -> String? {
+        var buffer: NSString?
+        scanString(string, into: &buffer)
         return buffer
     }
-    #elseif os(iOS) || os(macOS)
-    func scanString(string: String) -> String? {
+    #elseif os(iOS) || os(macOS) || os(watchOS)
+    func scanString(_ string: String) -> String? {
         var buffer: NSString?
-        _ = scanString(string, into: &buffer)
+        scanString(string, into: &buffer)
         return buffer as String?
     }
     #endif
-    #if os(iOS) || os(macOS)
+    #if os(iOS) || os(macOS) || os(watchOS)
     func scanUpToString(_ string: String) -> String? {
         var buffer: NSString?
         scanUpTo(string, into: &buffer)

--- a/Sources/String++.swift
+++ b/Sources/String++.swift
@@ -62,10 +62,10 @@ extension String {
 
         while !scanner.isAtEnd {
             key = scanner.scanUpToString("=")
-            _ = scanner.scanString(string: "=")
+            _ = scanner.scanString("=")
 
             value = scanner.scanUpToString("&")
-            _ = scanner.scanString(string: "&")
+            _ = scanner.scanString("&")
 
             if let key = key, let value = value {
                 parameters.updateValue(value, forKey: key)

--- a/Swifter.podspec
+++ b/Swifter.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.author    = "Matt Donnelly"
   s.ios.deployment_target = "10.0"
   s.osx.deployment_target = "10.10"
+  s.watchos.deployment_target = "5.0"
   s.source       = { :git => "https://github.com/mattdonnelly/Swifter.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/*.swift"
   s.swift_version = "5.0"


### PR DESCRIPTION
- Resolves an issue where when calling directly from watchOS 6, Dynamic Runtime may choose to opt to not use the extension version from String / Scanner (NSString and NSScanner as well) and provide an unexpected response
- Backports Swift 5 Foundation support to watchOS 5 for String++ and Scanner++
- Updated Swifter.podspec and Package.swift to support watchOS 5