### PR TITLE
fix archive error on Xcode12

### DIFF
--- a/Sources/URL++.swift
+++ b/Sources/URL++.swift
@@ -49,8 +49,8 @@ extension URL {
   
     var queryParamsForSSO: [String : String] {
         guard let host = self.host else { return [:] }
-        return host.split(separator: "&").reduce(into: [:]) { (result, parameter) in
-            let keyValue = parameter.split(separator: "=")
+        return host.components(separatedBy: "&").reduce(into: [:]) { (result, parameter) in
+            let keyValue = parameter.components(separatedBy: "=")
             result[String(keyValue[0])] = String(keyValue[1])
         }
     }


### PR DESCRIPTION
I faced archive error on building Xcode12 beta 4.

Error log.
> Undefined symbols for architecture armv7:
"type metadata for Swift._StringObject.Variant", referenced from:
outlined init with take of Swift._StringObject.Variant in URL++.o
ld: symbol(s) not found for architecture armv7
clang: error: linker command failed with exit code 1 (use -v to see invocation)

**Steps to reproduce**
1. Install Xcode12 beta 4
1. open project
1. run archive for iOS

I think the error is Xcode12's bug.

This PR is a workaround solution.

- replace string method .split with .components

Fixed close issue #311
