### PR TITLE
Store app credentials in gitignored file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ DerivedData
 *.xcuserstate
 .build
 
+MyAppCredentials.swift

--- a/SwifterDemoMac/ViewController.swift
+++ b/SwifterDemoMac/ViewController.swift
@@ -38,8 +38,8 @@ let authorizationMode: AuthorizationMode = .browser
 
 class ViewController: NSViewController {
     private var swifter = Swifter(
-        consumerKey: "nLl1mNYc25avPPF4oIzMyQzft",
-        consumerSecret: "Qm3e5JTXDhbbLl44cq6WdK00tSUwa17tWlO8Bf70douE4dcJe2"
+      consumerKey: myAppCredentials.consumerKey,
+      consumerSecret: myAppCredentials.consumerSecret
     )
     @objc dynamic var tweets: [Tweet] = []
     

--- a/SwifterDemoiOS/AuthViewController.swift
+++ b/SwifterDemoiOS/AuthViewController.swift
@@ -32,8 +32,8 @@ import AuthenticationServices
 
 class AuthViewController: UIViewController {
     private var swifter = Swifter(
-        consumerKey: "nLl1mNYc25avPPF4oIzMyQzft",
-        consumerSecret: "Qm3e5JTXDhbbLl44cq6WdK00tSUwa17tWlO8Bf70douE4dcJe2"
+      consumerKey: myAppCredentials.consumerKey,
+      consumerSecret: myAppCredentials.consumerSecret
     )
     private var jsonResult: [JSON] = []
 


### PR DESCRIPTION
People testing the demo may accidentally put their consumerkey and consumersecret in these version controlled files. This will avoid that.