### PR TITLE
fix json to support @dynamicMemberLookup

### DIFF
--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 
+@dynamicMemberLookup
 public enum JSON : Equatable, CustomStringConvertible {
     
     case string(String)
@@ -119,6 +120,13 @@ public enum JSON : Equatable, CustomStringConvertible {
     public var bool : Bool? {
         guard case .bool(let value) = self else {
             return nil
+        }
+        return value
+    }
+    
+    public subscript(dynamicMember key: String) -> JSON {
+        guard case .object(let dict) = self, let value = dict[key] else {
+            return .invalid
         }
         return value
     }

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		8BF1D6861948BCC100E3AA64 /* SwifterAccountsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */; };
 		8BF1D6881948C11E00E3AA64 /* SwifterCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */; };
 		8BF1D6891948C11E00E3AA64 /* SwifterCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */; };
+		9E9E62B1262DD83E0096340C /* DynamicMemberLookupJSONTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9E62B0262DD83E0096340C /* DynamicMemberLookupJSONTest.swift */; };
 		A1246D3A20F65E7300E1676E /* Tweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1246D3920F65E7300E1676E /* Tweet.swift */; };
 		A17A694F1C78336200063DFD /* Operator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator++.swift */; };
 		A17A69501C78336300063DFD /* Operator++.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17A694D1C78333400063DFD /* Operator++.swift */; };
@@ -197,6 +198,7 @@
 		8BF1D67E194889B900E3AA64 /* SwifterClientProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterClientProtocol.swift; sourceTree = "<group>"; };
 		8BF1D6841948BCC100E3AA64 /* SwifterAccountsClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterAccountsClient.swift; sourceTree = "<group>"; };
 		8BF1D6871948C11E00E3AA64 /* SwifterCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwifterCredential.swift; sourceTree = "<group>"; };
+		9E9E62B0262DD83E0096340C /* DynamicMemberLookupJSONTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicMemberLookupJSONTest.swift; sourceTree = "<group>"; };
 		A1246D3920F65E7300E1676E /* Tweet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tweet.swift; sourceTree = "<group>"; };
 		A17A694D1C78333400063DFD /* Operator++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Operator++.swift"; sourceTree = "<group>"; };
 		A198590E233737C400B63092 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 				DC7D6B721ECA5294008586E3 /* String+SwifterTests.swift */,
 				DC7D6B731ECA5294008586E3 /* SwifterTests.swift */,
 				4ED2E25B215E1E1A00E2084A /* JSONTest.swift */,
+				9E9E62B0262DD83E0096340C /* DynamicMemberLookupJSONTest.swift */,
 			);
 			name = SwifterTests;
 			path = Tests/SwifterTests;
@@ -729,6 +732,7 @@
 				4ED2E25C215E1E1A00E2084A /* JSONTest.swift in Sources */,
 				DC7D6B761ECA5294008586E3 /* SwifterTests.swift in Sources */,
 				DC7D6B751ECA5294008586E3 /* String+SwifterTests.swift in Sources */,
+				9E9E62B1262DD83E0096340C /* DynamicMemberLookupJSONTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swifter.xcodeproj/project.pbxproj
+++ b/Swifter.xcodeproj/project.pbxproj
@@ -1059,7 +1059,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattdonnelly.SwifteriOS.SwifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1075,7 +1075,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattdonnelly.SwifteriOS.SwifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Tests/SwifterTests/DynamicMemberLookupJSONTest.swift
+++ b/Tests/SwifterTests/DynamicMemberLookupJSONTest.swift
@@ -1,0 +1,73 @@
+//
+//  DynamicMemberLookupJSONTest.swift
+//  SwifterTests
+//
+//  Created by TOUYA KAWANO on 2021/04/20.
+//  Copyright © 2021 Matt Donnelly. All rights reserved.
+//
+
+
+import XCTest
+
+#if os(iOS)
+@testable import SwifteriOS
+#elseif os(macOS)
+@testable import SwifterMac
+#elseif os(Linux)
+@testable import Swifter
+#endif
+
+class DynamicMemberLookupJSONTest: XCTestCase {
+
+    func testDynamicMemberLookupJSON() throws {
+
+        let dummyTweetObject: [String: Any] = [
+            "retweeted": false,
+            "is_quote_status": false,
+            "created_at": "Sun Apr 18 23:54:27 +0000 2021",
+            "id_str": "1383931967297650690",
+            "full_text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "lang": "ja",
+            "user": [
+                "friends_count": 673.0,
+                "geo_enabled": false,
+                "profile_background_tile": false,
+                "translator_type": "none",
+                "profile_use_background_image": true,
+                "followers_count": 725.0,
+                "id_str": "1111111456788893",
+                "created_at": "Thu Aug 27 09:06:03 +0000 2009",
+                "profile_background_color": "BADFCD",
+                "favourites_count": 278.0
+            ],
+            "entities": [
+                "urls": [
+                    "http://www.example.com/",
+                    "https://www.example.com/",
+                    "http://www.example.com/brass.html?blow=army",
+                    "http://www.example.com/babies/bath.php",
+                    "http://www.example.com/?account=afterthought",
+                    "https://example.com/"
+                ]
+            ]
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: dummyTweetObject, options: [])
+        let json = try JSON.parse(jsonData: jsonData)
+
+        XCTContext.runActivity(named: "can get value") { _ in
+            XCTAssertEqual(json.id_str.string, dummyTweetObject["id_str"] as? String)
+            XCTAssertEqual(json.id_str.string, json["id_str"].string)
+        }
+
+        XCTContext.runActivity(named: "can access nested value") { _ in
+            XCTAssertEqual(json.user.created_at.string, json["user"]["created_at"].string)
+        }
+
+        XCTContext.runActivity(named: "wrong key") { _ in
+            XCTAssertTrue(json.xxxxxxxxxxxxxxxxxx == .invalid)
+            XCTAssertTrue(json["xxxxxxxxxxxxxxxxxx"] == .invalid)
+        }
+    }
+}
+


### PR DESCRIPTION
Hello. I fixed `JSON` type to support `@dynamicMemberLookup`.

```swift
@dynamicMemberLookup
public enum JSON : Equatable, CustomStringConvertible {

    ...

    public subscript(dynamicMember key: String) -> JSON {
        guard case .object(let dict) = self[key], let value = dict[key] else {
            return .invalid
        }
        return value
    }

    ...

}

```

↓usage

```swift
// before
cell.textLabel?.text = tweets[indexPath.row]["text"].string

// after
cell.textLabel?.text = tweets[indexPath.row].text.string
```
Currently, when accessing the JSON content, we need to specify the key name with `[""]`.
With support for @dynamicMemberLookup, we can access the JSON content without `[""]`.
And the benefits of traditional JSON will not be lost.
>  Swift's strict typing system and doesn't require you to constantly downcast accessed objects. It also removes the need for lots of optional chaining

Could you confirm?

(I’m Sorry if this suggestion has already been considered.
 I've checked the Issue and PR. But it may not be perfect...)